### PR TITLE
Fix/em test cases june

### DIFF
--- a/CheckEngine/CheckEngineRunner/Program.cs
+++ b/CheckEngine/CheckEngineRunner/Program.cs
@@ -65,8 +65,9 @@ namespace CheckEngineRunner
 
             */
 
+            string batchId = Guid.NewGuid().ToString();
+
             string fileTypeCd = ((args != null) && (args.Length >= 1)) ? args[0] : null;
-            fileTypeCd = "EM";
 
             switch (fileTypeCd)
             {
@@ -74,12 +75,11 @@ namespace CheckEngineRunner
                     {
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
 
-
                         string localDir = System.IO.Directory.GetCurrentDirectory();
                         string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\MonitorPlan\\obj\\Debug\\netcoreapp6.0\\";
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
-                        bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal);
+                        bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal, batchId);
                     }
                     break;
 
@@ -97,18 +97,37 @@ namespace CheckEngineRunner
                         string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\Emissions\\obj\\Debug\\netcoreapp6.0\\";
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
-                        bool result = checkEngine.RunChecks_EmReport("MDC-7743327CA4FB4B8CA6C0C656ECC4E1B8", 113, eCheckEngineRunMode.Normal);
+                        bool result = checkEngine.RunChecks_EmReport(monPlanId, rptPeriodId, eCheckEngineRunMode.Normal, batchId);
                     }
                     break;
 
                 case "QAT":
                     {
+                        string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
+                        string testSumId = ((args != null) && (args.Length >= 3)) ? args[2] : null;
+
+
                         string localDir = System.IO.Directory.GetCurrentDirectory();
                         string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp6.0\\";
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
 
-                        bool result = checkEngine.RunChecks_QaReport_Test("e39c510f-6cde-4555-a7b9-162cd5183ca5", "TWCORNEL5-C0E3879920A14159BAA98E03F1980A7A", eCheckEngineRunMode.Normal, "e39c510f-6cde-4555-a7b9-162cd5183ca5");
+                        bool result = checkEngine.RunChecks_QaReport_Test(testSumId, monPlanId, eCheckEngineRunMode.Normal, batchId);
+                    }
+                    break;
+
+                case "QCE":
+                    {
+                        string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
+                        string qaCertEventId = ((args != null) && (args.Length >= 3)) ? args[2] : null;
+
+
+                        string localDir = System.IO.Directory.GetCurrentDirectory();
+                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp6.0\\";
+                        cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
+
+
+                        bool result = checkEngine.RunChecks_QaReport_Qce(qaCertEventId, monPlanId, eCheckEngineRunMode.Normal, batchId);
                     }
                     break;
             }
@@ -126,6 +145,8 @@ namespace CheckEngineRunner
             JobDataMap dataMap = context.JobDetail.JobDataMap;
 
 
+            string batchId = Guid.NewGuid().ToString();
+
             string fileTypeCd = dataMap.GetString("fileTypeCd");
             string monPlanId = dataMap.GetString("monPlanId");
 
@@ -138,7 +159,7 @@ namespace CheckEngineRunner
                         string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\MonitorPlan\\obj\\Debug\\netcoreapp6.0\\";
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
-                        bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal);
+                        bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal, batchId);
                         await Task.CompletedTask;
                     }
                     break;
@@ -151,7 +172,7 @@ namespace CheckEngineRunner
                         string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp6.0\\";
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
-                        bool result = checkEngine.RunChecks_QaReport_Test(testSumId, monPlanId, eCheckEngineRunMode.Normal, testSumId);
+                        bool result = checkEngine.RunChecks_QaReport_Test(testSumId, monPlanId, eCheckEngineRunMode.Normal, batchId);
                         await Task.CompletedTask;
                     }
                     break;
@@ -164,7 +185,7 @@ namespace CheckEngineRunner
                         string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp3.1\\";
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
-                        bool result = checkEngine.RunChecks_QaReport_Qce(qaCertEventId, monPlanId, eCheckEngineRunMode.Normal, qaCertEventId);
+                        bool result = checkEngine.RunChecks_QaReport_Qce(qaCertEventId, monPlanId, eCheckEngineRunMode.Normal, batchId);
                         await Task.CompletedTask;
                     }
                     break;
@@ -177,7 +198,7 @@ namespace CheckEngineRunner
                         string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp3.1\\";
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
-                        bool result = checkEngine.RunChecks_QaReport_Tee(testExtenstionExemptionId, monPlanId, eCheckEngineRunMode.Normal, testExtenstionExemptionId);
+                        bool result = checkEngine.RunChecks_QaReport_Tee(testExtenstionExemptionId, monPlanId, eCheckEngineRunMode.Normal, batchId);
                         await Task.CompletedTask;
                     }
                     break;

--- a/CheckEngine/Emissions/EmissionReport/Categories/Other/Nsps4tSummaryDataCategory.cs
+++ b/CheckEngine/Emissions/EmissionReport/Categories/Other/Nsps4tSummaryDataCategory.cs
@@ -111,15 +111,15 @@ namespace ECMPS.Checks.EmissionsReport
             string monPlanId = emissionsReportProcess.CheckEngine.MonPlanId;
             int rptPeriodId = emissionsReportProcess.CheckEngine.RptPeriodId.Value;
 
-            result = InitSourceDataDo("nsps4t_summary_data", "ORIS_CODE, LOCATION_NAME", monPlanId, rptPeriodId, emissionsReportProcess) && result;
-            result = InitSourceDataDo("nsps4t_compliance_period_data", "ORIS_CODE, LOCATION_NAME, END_YEAR desc, END_MONTH desc", monPlanId, rptPeriodId, emissionsReportProcess) && result;
-            result = InitSourceDataDo("nsps4t_annual_data", "ORIS_CODE, LOCATION_NAME", monPlanId, rptPeriodId, emissionsReportProcess) && result;
+            result = InitSourceDataDo("Nsps4tSummary", "nsps4t_summary_data", "ORIS_CODE, LOCATION_NAME", monPlanId, rptPeriodId, emissionsReportProcess) && result;
+            result = InitSourceDataDo("Nsps4tCompliancePeriod", "nsps4t_compliance_period_data", "ORIS_CODE, LOCATION_NAME, END_YEAR desc, END_MONTH desc", monPlanId, rptPeriodId, emissionsReportProcess) && result;
+            result = InitSourceDataDo("Nsps4tAnnual", "nsps4t_annual_data", "ORIS_CODE, LOCATION_NAME", monPlanId, rptPeriodId, emissionsReportProcess) && result;
 
             return result;
         }
 
 
-        private static bool InitSourceDataDo(string sourceName, string sourceSort, string monPlanId, int rptPeriodId,
+        private static bool InitSourceDataDo(string targetName, string sourceName, string sourceSort, string monPlanId, int rptPeriodId,
                                              cEmissionsReportProcess emissionsReportProcess)
         {
             bool result = true;
@@ -133,7 +133,7 @@ namespace ECMPS.Checks.EmissionsReport
                 //SqlDataAdapter Adapter = new SqlDataAdapter(sql, sqlConnection);
                 NpgsqlDataAdapter Adapter = new NpgsqlDataAdapter(sql, sqlConnection);
                 DataSet sourceDataSet = emissionsReportProcess.SourceData;
-                DataTable Table = new DataTable(sourceName);
+                DataTable Table = new DataTable(targetName);
                 
                 // this defaults to 30 seconds if we don't override it
                 if (Adapter.SelectCommand != null)


### PR DESCRIPTION
Changes needed to complete EM Evaluation test case runs.

1) Changes to use command line parameters instead of hardcoding to run EM, QAT and QCE evaluations.
2) Changes to pass Batch Id from the Check Runner.
3) Changes to the loading of NSPS4T data to use separate name for the DB procedures and internal tables.