### PR TITLE
Fix/compliance datasets do not include data

### DIFF
--- a/Logger/Logger.csproj
+++ b/Logger/Logger.csproj
@@ -2,7 +2,6 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
-    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </ItemGroup>
 
   <PropertyGroup>

--- a/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
@@ -90,8 +90,6 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       try
       {
 
-        List<List<Object>> rowsPerPrg = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.vw_allowance_based_compliance_bulk_files_to_generate", 1);
-
         jl.JobId = job_id;
         jl.JobSystem = "Quartz";
         jl.JobClass = "Bulk Data File";
@@ -104,6 +102,9 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         _dbContext.JobLogs.Add(jl);
         await _dbContext.SaveChangesAsync();
         
+        List<List<Object>> rowsPerPrg = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.vw_allowance_based_compliance_bulk_files_to_generate", 1);
+
+
         for(int row = 0; row < rowsPerPrg.Count; row++){
           string code = (string) rowsPerPrg[row][0];
           string urlParams = "programCodeInfo=" + code;

--- a/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
@@ -69,7 +69,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     public async Task Execute(IJobExecutionContext context)
     {
       // Does this job already exist? Otherwise create and schedule a new copy
-      List<List<Object>> jobAlreadyExists = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.job_log WHERE job_name = 'Emissions Compliance' AND add_date::date = now()::date;", 9);
+      List<List<Object>> jobAlreadyExists = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.job_log WHERE job_name = 'Allowance Compliance' AND add_date::date = now()::date;", 9);
       if(jobAlreadyExists.Count != 0){
         return; // Job already exists , do not run again
       }

--- a/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
@@ -90,6 +90,8 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       try
       {
 
+        List<List<Object>> rowsPerPrg = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.vw_allowance_based_compliance_bulk_files_to_generate", 1);
+
         jl.JobId = job_id;
         jl.JobSystem = "Quartz";
         jl.JobClass = "Bulk Data File";
@@ -101,9 +103,6 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         _dbContext.JobLogs.Add(jl);
         await _dbContext.SaveChangesAsync();
-        
-        List<List<Object>> rowsPerPrg = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.vw_allowance_based_compliance_bulk_files_to_generate", 1);
-        
         
         for(int row = 0; row < rowsPerPrg.Count; row++){
           string code = (string) rowsPerPrg[row][0];

--- a/admin/Jobs/BulkDataFiles/BulkDataFilesMaintenance.cs
+++ b/admin/Jobs/BulkDataFiles/BulkDataFilesMaintenance.cs
@@ -99,7 +99,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         }
 
         _dbContext.ExecuteSql("DELETE from camdaux.bulk_file_queue where add_date < now() - interval '30 days'");
-        _dbContext.ExecuteSql("DELETE from camdaux.job_log where add_date < now() - interval '30 days'");
+        _dbContext.ExecuteSql("DELETE from camdaux.job_log where add_date < now() - interval '90 days'");
 
         _dbContext.ExecuteSql("CALL camdaux.procedure_bulk_file_requeue_check();");
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
     memory: ((memory))
     instances: ((instances))
     buildpacks:
-      - dotnet_core_buildpack
+      - https://github.com/cloudfoundry/dotnet-core-buildpack.git#v2.4.15
     health-check-type: ((healthCheckType))
     env:
       OPTIMIZE_MEMORY: true


### PR DESCRIPTION
## Ticket
[compliance datasets do not include data.](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/6031)

## Changes

1. Changed the jobAlreadyExists query 'Emissions Compliance' to 'Allowance Compliance' 

- I set `EASEY_DATAMART_BYPASS` to `true` in locally to update `camdaux.job_log` because `camdaux.job_log`’s `job_name` 'Datamart Nightly' `add_date` value is not today's date.
2. extend to 90 days to clear rows older job log