### PR TITLE
fix/compliance datasets do not include data

### DIFF
--- a/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
@@ -69,7 +69,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     public async Task Execute(IJobExecutionContext context)
     {
       // Does this job already exist? Otherwise create and schedule a new copy
-      List<List<Object>> jobAlreadyExists = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.job_log WHERE job_name = 'Emissions Compliance' AND add_date::date = now()::date;", 9);
+      List<List<Object>> jobAlreadyExists = await _dbContext.ExecuteSqlQuery("SELECT * FROM camdaux.job_log WHERE job_name = 'Allowance Compliance' AND add_date::date = now()::date;", 9);
       if(jobAlreadyExists.Count != 0){
         return; // Job already exists , do not run again
       }

--- a/admin/Jobs/BulkDataFiles/BulkDataFilesMaintenance.cs
+++ b/admin/Jobs/BulkDataFiles/BulkDataFilesMaintenance.cs
@@ -99,7 +99,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         }
 
         _dbContext.ExecuteSql("DELETE from camdaux.bulk_file_queue where add_date < now() - interval '30 days'");
-        _dbContext.ExecuteSql("DELETE from camdaux.job_log where add_date < now() - interval '30 days'");
+        _dbContext.ExecuteSql("DELETE from camdaux.job_log where add_date < now() - interval '90 days'");
 
         _dbContext.ExecuteSql("CALL camdaux.procedure_bulk_file_requeue_check();");
 


### PR DESCRIPTION
## Ticket
[compliance datasets do not include data.](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/6031)

## Changes
1. Changed the jobAlreadyExists query 'Emissions Compliance' to 'Allowance Compliance'

- I set EASEY_DATAMART_BYPASS to true in locally to update camdaux.job_log because camdaux.job_log’s job_name 'Datamart Nightly' add_date value is not today's date.

2. extend to 90 days to clear rows older job log