### PR TITLE
#6031 Including ValidateExecutableReferencesMatchSelfContained = false

### DIFF
--- a/Logger/Logger.csproj
+++ b/Logger/Logger.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
+    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Included the following in the Logger.csproj file.

    <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
