### PR TITLE
fix: updated CheckEngineRunner paths to be Unix-compatible

### DIFF
--- a/CheckEngine/CheckEngineRunner/Program.cs
+++ b/CheckEngine/CheckEngineRunner/Program.cs
@@ -4,6 +4,7 @@ using ECMPS.Checks.CheckEngine.Definitions;
 using Quartz;
 using Quartz.Impl;
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace CheckEngineRunner
@@ -69,14 +70,16 @@ namespace CheckEngineRunner
 
             string fileTypeCd = ((args != null) && (args.Length >= 1)) ? args[0] : null;
 
+            string localDir = System.IO.Directory.GetCurrentDirectory();
+            string baseDir = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11);
+
             switch (fileTypeCd)
             {
                 case "MP":
                     {
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
 
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\MonitorPlan\\obj\\Debug\\netcoreapp6.0\\";
+                        string dllPath = Path.Combine(baseDir, "MonitorPlan", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal, batchId);
@@ -93,8 +96,7 @@ namespace CheckEngineRunner
                             if (!int.TryParse(rpPeriodIdText, out rptPeriodId)) { rptPeriodId = 0; }
                         }
 
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\Emissions\\obj\\Debug\\netcoreapp6.0\\";
+                        string dllPath = Path.Combine(baseDir, "Emissions", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_EmReport(monPlanId, rptPeriodId, eCheckEngineRunMode.Normal, batchId);
@@ -106,9 +108,7 @@ namespace CheckEngineRunner
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
                         string testSumId = ((args != null) && (args.Length >= 3)) ? args[2] : null;
 
-
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp6.0\\";
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
 
@@ -121,9 +121,7 @@ namespace CheckEngineRunner
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
                         string qaCertEventId = ((args != null) && (args.Length >= 3)) ? args[2] : null;
 
-
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp6.0\\";
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
 
@@ -150,13 +148,15 @@ namespace CheckEngineRunner
             string fileTypeCd = dataMap.GetString("fileTypeCd");
             string monPlanId = dataMap.GetString("monPlanId");
 
+            string localDir = System.IO.Directory.GetCurrentDirectory();
+            string baseDir = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11);
+
 
             switch (fileTypeCd)
             {
                 case "MP":
                     {
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\MonitorPlan\\obj\\Debug\\netcoreapp6.0\\";
+                        string dllPath = Path.Combine(baseDir, "MonitorPlan", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal, batchId);
@@ -168,8 +168,7 @@ namespace CheckEngineRunner
                     {
                         string testSumId = dataMap.GetString("otherId");
 
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp6.0\\";
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_QaReport_Test(testSumId, monPlanId, eCheckEngineRunMode.Normal, batchId);
@@ -181,8 +180,7 @@ namespace CheckEngineRunner
                     {
                         string qaCertEventId = dataMap.GetString("otherId");
 
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp3.1\\";
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp3.1") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_QaReport_Qce(qaCertEventId, monPlanId, eCheckEngineRunMode.Normal, batchId);
@@ -194,8 +192,7 @@ namespace CheckEngineRunner
                     {
                         string testExtenstionExemptionId = dataMap.GetString("otherId");
 
-                        string localDir = System.IO.Directory.GetCurrentDirectory();
-                        string dllPath = localDir.Substring(0, localDir.IndexOf("CheckEngine") + 11) + "\\QA\\obj\\Debug\\netcoreapp3.1\\";
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp3.1") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_QaReport_Tee(testExtenstionExemptionId, monPlanId, eCheckEngineRunMode.Normal, batchId);


### PR DESCRIPTION
## Main Changes

- Updated the `CheckEngineRunner` to use `Path.Combine` instead of hard-coded paths with backslashes. This allows the application to be run on UNIX operating systems / WSL.
