### PR TITLE
Fix/6385 suppressions not suppressing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # User-specific files
 .env
 .env.*
+.envrc
 *.suo
 *.user
 *.userosscache

--- a/CheckEngine/CheckEngine/ErrorSuppression/cErrorSuppressCriteria.cs
+++ b/CheckEngine/CheckEngine/ErrorSuppression/cErrorSuppressCriteria.cs
@@ -73,8 +73,8 @@ namespace ECMPS.ErrorSuppression
       {
         match = false;
       }
-      else if (LocationNameList.HasValue() && 
-               (!errorSuppressValues.LocationName.HasValue() ||
+      else if (!LocationNameList.IsEmpty() && 
+               (errorSuppressValues.LocationName.IsEmpty() ||
                 errorSuppressValues.LocationName.ToUpper().NotInList(LocationNameList.ToUpper())))
       {
         match = false;

--- a/CheckEngine/CheckEngine/ErrorSuppression/cErrorSuppressCriteria.cs
+++ b/CheckEngine/CheckEngine/ErrorSuppression/cErrorSuppressCriteria.cs
@@ -79,7 +79,7 @@ namespace ECMPS.ErrorSuppression
       {
         match = false;
       }
-      else if ((EsMatchDataTypeCd != null) && (MatchDataValue != null) &&
+      else if (!EsMatchDataTypeCd.IsEmpty() && !MatchDataValue.IsEmpty() &&
           ((errorSuppressValues.EsMatchDataTypeCd != EsMatchDataTypeCd) ||
            (errorSuppressValues.MatchDataValue != MatchDataValue)))
       {
@@ -92,7 +92,7 @@ namespace ECMPS.ErrorSuppression
       {
         match = false;
       }
-      else if ((EsMatchTimeTypeCd != null) && (EsMatchTimeTypeCd != "HISTIND") &&
+      else if (!EsMatchTimeTypeCd.IsEmpty() && (EsMatchTimeTypeCd != "HISTIND") &&
                ((MatchTimeBeginValue != null) || (MatchTimeEndValue != null)) &&
                ((errorSuppressValues.EsMatchTimeTypeCd != EsMatchTimeTypeCd) ||
                 errorSuppressValues.MatchTimeValue.NotBetween(MatchTimeBeginValue, MatchTimeEndValue)))


### PR DESCRIPTION
## Related Issues

- [#6385](https://github.com/US-EPA-CAMD/easey-ui/issues/6385)

## Main Changes

- Expanded the `LocationNameList` check from just a NULL check (`HasValue`) to a NULL or empty string check (`IsEmpty`) when matching the target evaluation against error suppressions. This is necessary because the `LocationNameList` value is coerced to a string after it is pulled from the database.
- Performed the same change for other criteria with values that have been coerced with the `AsString` method.

## Note

See `CheckEngine/CheckEngine/ResultCatalog.cs` lines 834-839 for the criteria that are coerced to strings.