### PR TITLE
Feature/5576 process inventory changes

### DIFF
--- a/admin/Jobs/InventoryChanges.cs
+++ b/admin/Jobs/InventoryChanges.cs
@@ -134,8 +134,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
           // Call the stored procedure `camdecmpswks.update_mp_eval_status_and_reporting_freq` for each log record.
           // This is done sequentially to ensure that the records are processed in the same order that they were retrieved.
-          var connectionString = _dbContext.Database.GetConnectionString();
-          var connection = new NpgsqlConnection(connectionString);
+          var connection = new NpgsqlConnection(_dbContext.Database.GetConnectionString());
           var sqlTransaction = connection.BeginTransaction();
           try
           {
@@ -200,7 +199,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
     private void UpdateMpEvalStatusAndReportingFreq(InventoryStatusLog inventoryStatusLog, NpgsqlConnection connection, NpgsqlTransaction sqlTransaction)
     {
-        var parameters = new List<NpgsqlParameter>
+      var parameters = new List<NpgsqlParameter>
         {
           _dbContext.CreateParameter("par_V_UNIT_ID", inventoryStatusLog.UnitId.ToString(), NpgsqlDbType.Numeric, ParameterDirection.Input),
           _dbContext.CreateParameter("par_V_DATA_TYPE_CD", inventoryStatusLog.DataTypeCd, NpgsqlDbType.Varchar, ParameterDirection.Input),

--- a/admin/Jobs/InventoryChanges.cs
+++ b/admin/Jobs/InventoryChanges.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz;
+using SilkierQuartz;
+
+using Epa.Camd.Quartz.Scheduler.Models;
+
+namespace Epa.Camd.Quartz.Scheduler.Jobs
+{
+    public class InventoryChanges : IJob
+    {
+        private Guid job_id = Guid.NewGuid();
+
+        private NpgSqlContext _dbContext = null;
+
+        private IConfiguration Configuration { get; }
+
+        public static class InventoryChangesIdentity
+        {
+            public static readonly string Group = Constants.QuartzGroups.MAINTAINANCE;
+            public static readonly string JobName = "Inventory Changes";
+            public static readonly string JobDescription = "Operates on an interval to determine if any remote facility/unit inventory changes require changes to existing monitoring plans.";
+            public static readonly string TriggerName = "Check status log every 5 minutes";
+            public static readonly string TriggerDescription = "Operate every 5 minutes to determine if there are any new changes recorded in the inventory status log.";
+        }
+
+        public static void RegisterWithQuartz(IServiceCollection services)
+        {
+            services.AddQuartzJob<InventoryChanges>(WithInventoryChangesKey(), InventoryChangesIdentity.JobDescription);
+        }
+
+        public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app)
+        {
+            try
+            {
+                JobKey jobKey = WithInventoryChangesKey();
+                string cronExpression = Utils.Configuration["EASEY_QUARTZ_SCHEDULER_INVENTORY_CHANGES_SCHEDULE"] ?? "0 0/5 * * * ?";
+                TriggerBuilder triggerBuilder = WithInventoryChangesCronSchedule(cronExpression);
+
+                if (await scheduler.CheckExists(jobKey))
+                {
+                    ITrigger trigger = await scheduler.GetTrigger(WithInventoryChangesTriggerKey());
+
+                    if (
+                      trigger is ICronTrigger cronTrigger &&
+                      cronTrigger.CronExpressionString != cronExpression
+                    )
+                    {
+                        await scheduler.RescheduleJob(WithInventoryChangesTriggerKey(), triggerBuilder.Build());
+                        Console.WriteLine($"Rescheduled {jobKey.Name} with cron expression [{cronExpression}]");
+                    }
+                }
+                else
+                {
+                    app.UseQuartzJob<InventoryChanges>(triggerBuilder);
+                    Console.WriteLine($"Scheduled {jobKey.Name} with cron expression [{cronExpression}]");
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("ERROR");
+                Console.WriteLine(e.Message);
+            }
+        }
+
+        public InventoryChanges(NpgSqlContext dbContext, IConfiguration configuration)
+        {
+            _dbContext = dbContext;
+            Configuration = configuration;
+        }
+
+        public async Task Execute(IJobExecutionContext context)
+        {
+            Console.Write("Checking Status Log Now");
+
+            try
+            {
+                // Get the last job log record for the job name "Inventory Changes".
+                JobLog lastJobLog = _dbContext.JobLogs.FromSqlRaw($@"
+                        SELECT * FROM camdaux.job_log
+                        WHERE job_name = '{jl.JobName}'
+                        ORDER BY start_date DESC
+                        LIMIT 1"
+                        ).FirstOrDefault();
+
+                // Check the status of the last job log. If the status is "WIP", then return.
+                if (lastJobLog != null && lastJobLog.StatusCd == "WIP")
+                {
+                    return;
+                }
+
+                JobLog jl = new JobLog();
+                try
+                {
+                    jl.JobId = job_id;
+                    jl.JobSystem = "Quartz";
+                    jl.JobClass = "Maintainance";
+                    jl.JobName = "Inventory Changes";
+                    jl.AddDate = Utils.getCurrentEasternTime();
+                    jl.StartDate = Utils.getCurrentEasternTime();
+                    jl.EndDate = null;
+                    jl.StatusCd = "WIP";
+                    _dbContext.JobLogs.Add(jl);
+                    await _dbContext.SaveChangesAsync();
+
+                    // Get the last processed inventory status log ID from the additional details of the last job log.
+                    int lastProcessedInventoryStatusLogId = 0;
+                    if (lastJobLog != null && lastJobLog.AdditionalDetails != null)
+                    {
+                        lastProcessedInventoryStatusLogId = JsonConvert.DeserializeObject<InventoryChangesJobLogAdditionalDetails>(lastJobLog.AdditionalDetails).LastProcessedInventoryStatusLogId;
+                    }
+
+                    // Retrieve all inventory status log records after the last processed log and with a data type code of eith `INVENTORY` or `UNIT_PROGRAM`.
+                    List<InventoryStatusLog> inventoryStatusLogs = _dbContext.InventoryStatusLogs.FromSqlRaw($@"
+                        SELECT * FROM camdaux.inventory_status_log
+                        WHERE inventory_status_log_id > {lastProcessedInventoryStatusLogId}
+                        AND data_type_cd IN ('INVENTORY', 'UNIT_PROGRAM')
+                        ORDER BY inventory_status_log_id"
+                        ).ToList();
+
+                    // TODO: Call the stored procedure `camdecmpswks.update_mp_eval_status_and_reporting_freq` for each log record.
+
+                    // TODO: Update the additional details table with the ID of the last processed inventory status log.
+
+                    jl.StatusCd = "COMPLETE";
+                    jl.EndDate = Utils.getCurrentEasternTime();
+                    _dbContext.JobLogs.Update(jl);
+                    await _dbContext.SaveChangesAsync();
+                }
+                catch (Exception e)
+                {
+                    jl.StatusCd = "ERROR";
+                    jl.EndDate = Utils.getCurrentEasternTime();
+                    jl.AdditionalDetails = e.Message;
+                    _dbContext.JobLogs.Update(jl);
+                    await _dbContext.SaveChangesAsync();
+                    Console.Write(e.Message);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.Write(e.Message);
+            }
+        }
+
+        public static JobKey WithInventoryChangesKey()
+        {
+            return new JobKey(InventoryChangesIdentity.JobName, InventoryChangesIdentity.Group);
+        }
+
+        public static TriggerKey WithInventoryChangesTriggerKey()
+        {
+            return new TriggerKey(InventoryChangesIdentity.TriggerName, InventoryChangesIdentity.Group);
+        }
+
+        public static IJobDetail WithInventoryChangesJobDetail()
+        {
+            return JobBuilder.Create<InventoryChanges>()
+                .WithIdentity(WithInventoryChangesKey())
+                .WithDescription(InventoryChangesIdentity.JobDescription)
+                .Build();
+        }
+
+        public static TriggerBuilder WithInventoryChangesCronSchedule(string cronExpression)
+        {
+            return TriggerBuilder.Create()
+                .WithIdentity(WithInventoryChangesTriggerKey())
+                .WithDescription(InventoryChangesIdentity.TriggerDescription)
+                .WithSchedule(CronScheduleBuilder.CronSchedule(cronExpression).InTimeZone(Utils.getCurrentEasternZone()));
+        }
+    }
+}

--- a/admin/Jobs/InventoryChanges.cs
+++ b/admin/Jobs/InventoryChanges.cs
@@ -11,166 +11,216 @@ using Epa.Camd.Quartz.Scheduler.Models;
 
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
-    public class InventoryChanges : IJob
+  public class InventoryChanges : IJob
+  {
+    private Guid job_id = Guid.NewGuid();
+
+    private NpgSqlContext _dbContext = null;
+
+    private IConfiguration Configuration { get; }
+
+    public static class InventoryChangesIdentity
     {
-        private Guid job_id = Guid.NewGuid();
+      public static readonly string Group = Constants.QuartzGroups.MAINTAINANCE;
+      public static readonly string JobName = "Inventory Changes";
+      public static readonly string JobDescription = "Operates on an interval to determine if any remote facility/unit inventory changes require changes to existing monitoring plans.";
+      public static readonly string TriggerName = "Check status log every 5 minutes";
+      public static readonly string TriggerDescription = "Operate every 5 minutes to determine if there are any new changes recorded in the inventory status log.";
+    }
 
-        private NpgSqlContext _dbContext = null;
+    public static void RegisterWithQuartz(IServiceCollection services)
+    {
+      services.AddQuartzJob<InventoryChanges>(WithInventoryChangesKey(), InventoryChangesIdentity.JobDescription);
+    }
 
-        private IConfiguration Configuration { get; }
+    public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app)
+    {
+      try
+      {
+        JobKey jobKey = WithInventoryChangesKey();
+        string cronExpression = Utils.Configuration["EASEY_QUARTZ_SCHEDULER_INVENTORY_CHANGES_SCHEDULE"] ?? "0 0/5 * * * ?";
+        TriggerBuilder triggerBuilder = WithInventoryChangesCronSchedule(cronExpression);
 
-        public static class InventoryChangesIdentity
+        if (await scheduler.CheckExists(jobKey))
         {
-            public static readonly string Group = Constants.QuartzGroups.MAINTAINANCE;
-            public static readonly string JobName = "Inventory Changes";
-            public static readonly string JobDescription = "Operates on an interval to determine if any remote facility/unit inventory changes require changes to existing monitoring plans.";
-            public static readonly string TriggerName = "Check status log every 5 minutes";
-            public static readonly string TriggerDescription = "Operate every 5 minutes to determine if there are any new changes recorded in the inventory status log.";
+          ITrigger trigger = await scheduler.GetTrigger(WithInventoryChangesTriggerKey());
+
+          if (
+            trigger is ICronTrigger cronTrigger &&
+            cronTrigger.CronExpressionString != cronExpression
+          )
+          {
+            await scheduler.RescheduleJob(WithInventoryChangesTriggerKey(), triggerBuilder.Build());
+            Console.WriteLine($"Rescheduled {jobKey.Name} with cron expression [{cronExpression}]");
+          }
+        }
+        else
+        {
+          app.UseQuartzJob<InventoryChanges>(triggerBuilder);
+          Console.WriteLine($"Scheduled {jobKey.Name} with cron expression [{cronExpression}]");
+        }
+      }
+      catch (Exception e)
+      {
+        Console.WriteLine("ERROR");
+        Console.WriteLine(e.Message);
+      }
+    }
+
+    public InventoryChanges(NpgSqlContext dbContext, IConfiguration configuration)
+    {
+      _dbContext = dbContext;
+      Configuration = configuration;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+      Console.Write("Starting Inventory Changes job");
+
+      try
+      {
+        if (IsJobInProgress())
+        {
+          Console.Write("Inventory Changes job is already in progress, skipping");
+          return;
         }
 
-        public static void RegisterWithQuartz(IServiceCollection services)
-        {
-            services.AddQuartzJob<InventoryChanges>(WithInventoryChangesKey(), InventoryChangesIdentity.JobDescription);
-        }
-
-        public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app)
-        {
-            try
-            {
-                JobKey jobKey = WithInventoryChangesKey();
-                string cronExpression = Utils.Configuration["EASEY_QUARTZ_SCHEDULER_INVENTORY_CHANGES_SCHEDULE"] ?? "0 0/5 * * * ?";
-                TriggerBuilder triggerBuilder = WithInventoryChangesCronSchedule(cronExpression);
-
-                if (await scheduler.CheckExists(jobKey))
-                {
-                    ITrigger trigger = await scheduler.GetTrigger(WithInventoryChangesTriggerKey());
-
-                    if (
-                      trigger is ICronTrigger cronTrigger &&
-                      cronTrigger.CronExpressionString != cronExpression
-                    )
-                    {
-                        await scheduler.RescheduleJob(WithInventoryChangesTriggerKey(), triggerBuilder.Build());
-                        Console.WriteLine($"Rescheduled {jobKey.Name} with cron expression [{cronExpression}]");
-                    }
-                }
-                else
-                {
-                    app.UseQuartzJob<InventoryChanges>(triggerBuilder);
-                    Console.WriteLine($"Scheduled {jobKey.Name} with cron expression [{cronExpression}]");
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine("ERROR");
-                Console.WriteLine(e.Message);
-            }
-        }
-
-        public InventoryChanges(NpgSqlContext dbContext, IConfiguration configuration)
-        {
-            _dbContext = dbContext;
-            Configuration = configuration;
-        }
-
-        public async Task Execute(IJobExecutionContext context)
-        {
-            Console.Write("Checking Status Log Now");
-
-            try
-            {
-                // Get the last job log record for the job name "Inventory Changes".
-                JobLog lastJobLog = _dbContext.JobLogs.FromSqlRaw($@"
+        // Get the last job log record for the job name "Inventory Changes".
+        JobLog lastCompletedJobLog = _dbContext.JobLogs.FromSqlRaw($@"
                         SELECT * FROM camdaux.job_log
-                        WHERE job_name = '{jl.JobName}'
+                        WHERE job_name = '{InventoryChangesIdentity.JobName}'
+                        AND status_cd = 'COMPLETE'
                         ORDER BY start_date DESC
                         LIMIT 1"
-                        ).FirstOrDefault();
+                ).FirstOrDefault();
 
-                // Check the status of the last job log. If the status is "WIP", then return.
-                if (lastJobLog != null && lastJobLog.StatusCd == "WIP")
-                {
-                    return;
-                }
+        JobLog jl = new JobLog();
+        try
+        {
+          jl.JobId = job_id;
+          jl.JobSystem = "Quartz";
+          jl.JobClass = "Maintainance";
+          jl.JobName = InventoryChangesIdentity.JobName;
+          jl.AddDate = Utils.getCurrentEasternTime();
+          jl.StartDate = Utils.getCurrentEasternTime();
+          jl.EndDate = null;
+          jl.StatusCd = "WIP";
+          _dbContext.JobLogs.Add(jl);
+          await _dbContext.SaveChangesAsync();
 
-                JobLog jl = new JobLog();
-                try
-                {
-                    jl.JobId = job_id;
-                    jl.JobSystem = "Quartz";
-                    jl.JobClass = "Maintainance";
-                    jl.JobName = "Inventory Changes";
-                    jl.AddDate = Utils.getCurrentEasternTime();
-                    jl.StartDate = Utils.getCurrentEasternTime();
-                    jl.EndDate = null;
-                    jl.StatusCd = "WIP";
-                    _dbContext.JobLogs.Add(jl);
-                    await _dbContext.SaveChangesAsync();
+          // Get the last processed inventory status log ID from the additional details of the last job log.
+          int lastProcessedInventoryStatusLogId = 0;
+          if (lastCompletedJobLog != null && lastCompletedJobLog.AdditionalDetails != null)
+          {
+            lastProcessedInventoryStatusLogId = JsonConvert.DeserializeObject<InventoryChangesJobLogAdditionalDetails>(lastCompletedJobLog.AdditionalDetails).LastProcessedInventoryStatusLogId;
+          }
+          // Initialize the additional details of the job log with the last processed inventory status log ID.
+          jl.AdditionalDetails = JsonConvert.SerializeObject(new InventoryChangesJobLogAdditionalDetails { LastProcessedInventoryStatusLogId = lastProcessedInventoryStatusLogId });
 
-                    // Get the last processed inventory status log ID from the additional details of the last job log.
-                    int lastProcessedInventoryStatusLogId = 0;
-                    if (lastJobLog != null && lastJobLog.AdditionalDetails != null)
-                    {
-                        lastProcessedInventoryStatusLogId = JsonConvert.DeserializeObject<InventoryChangesJobLogAdditionalDetails>(lastJobLog.AdditionalDetails).LastProcessedInventoryStatusLogId;
-                    }
-
-                    // Retrieve all inventory status log records after the last processed log and with a data type code of eith `INVENTORY` or `UNIT_PROGRAM`.
-                    List<InventoryStatusLog> inventoryStatusLogs = _dbContext.InventoryStatusLogs.FromSqlRaw($@"
+          // Retrieve all inventory status log records after the last processed log and with a data type code of eith `INVENTORY` or `UNIT_PROGRAM`.
+          List<InventoryStatusLog> inventoryStatusLogs = _dbContext.InventoryStatusLogs.FromSqlRaw($@"
                         SELECT * FROM camdaux.inventory_status_log
                         WHERE inventory_status_log_id > {lastProcessedInventoryStatusLogId}
                         AND data_type_cd IN ('INVENTORY', 'UNIT_PROGRAM')
                         ORDER BY inventory_status_log_id"
-                        ).ToList();
+              ).ToList();
 
-                    // TODO: Call the stored procedure `camdecmpswks.update_mp_eval_status_and_reporting_freq` for each log record.
-
-                    // TODO: Update the additional details table with the ID of the last processed inventory status log.
-
-                    jl.StatusCd = "COMPLETE";
-                    jl.EndDate = Utils.getCurrentEasternTime();
-                    _dbContext.JobLogs.Update(jl);
-                    await _dbContext.SaveChangesAsync();
-                }
-                catch (Exception e)
-                {
-                    jl.StatusCd = "ERROR";
-                    jl.EndDate = Utils.getCurrentEasternTime();
-                    jl.AdditionalDetails = e.Message;
-                    _dbContext.JobLogs.Update(jl);
-                    await _dbContext.SaveChangesAsync();
-                    Console.Write(e.Message);
-                }
-            }
-            catch (Exception e)
+          // Call the stored procedure `camdecmpswks.update_mp_eval_status_and_reporting_freq` for each log record.
+          // This is done sequentially to ensure that the records are processed in the same order that they were retrieved.
+          NpgsqlTransaction sqlTransaction = mCheckEngine.DbDataConnection.BeginTransaction();
+          try
+          {
+            foreach (InventoryStatusLog inventoryStatusLog in inventoryStatusLogs)
             {
-                Console.Write(e.Message);
+              UpdateMpEvalStatusAndReportingFreq(inventoryStatusLog, sqlTransaction);
+              // Update the additional details table with the ID of the last processed inventory status log.
+              jl.AdditionalDetails = JsonConvert.SerializeObject(new InventoryChangesJobLogAdditionalDetails { LastProcessedInventoryStatusLogId = inventoryStatusLog.InventoryStatusLogId });
             }
-        }
+            sqlTransaction.Commit();
+          }
+          catch (Exception e)
+          {
+            sqlTransaction.Rollback();
+            throw;
+          }
 
-        public static JobKey WithInventoryChangesKey()
-        {
-            return new JobKey(InventoryChangesIdentity.JobName, InventoryChangesIdentity.Group);
+          jl.StatusCd = "COMPLETE";
+          jl.EndDate = Utils.getCurrentEasternTime();
+          _dbContext.JobLogs.Update(jl);
+          await _dbContext.SaveChangesAsync();
         }
+        catch (Exception e)
+        {
+          jl.StatusCd = "ERROR";
+          jl.EndDate = Utils.getCurrentEasternTime();
+          jl.AdditionalDetails = e.Message;
+          _dbContext.JobLogs.Update(jl);
+          await _dbContext.SaveChangesAsync();
+          throw;
+        }
+      }
+      catch (Exception e)
+      {
+        Console.Write(e.Message);
+      }
 
-        public static TriggerKey WithInventoryChangesTriggerKey()
-        {
-            return new TriggerKey(InventoryChangesIdentity.TriggerName, InventoryChangesIdentity.Group);
-        }
-
-        public static IJobDetail WithInventoryChangesJobDetail()
-        {
-            return JobBuilder.Create<InventoryChanges>()
-                .WithIdentity(WithInventoryChangesKey())
-                .WithDescription(InventoryChangesIdentity.JobDescription)
-                .Build();
-        }
-
-        public static TriggerBuilder WithInventoryChangesCronSchedule(string cronExpression)
-        {
-            return TriggerBuilder.Create()
-                .WithIdentity(WithInventoryChangesTriggerKey())
-                .WithDescription(InventoryChangesIdentity.TriggerDescription)
-                .WithSchedule(CronScheduleBuilder.CronSchedule(cronExpression).InTimeZone(Utils.getCurrentEasternZone()));
-        }
+      Console.Write("Completed Inventory Changes job");
     }
+
+    private IsJobInProgress()
+    {
+      // Get the last job log record for the job name "Inventory Changes".
+      JobLog lastJobLog = _dbContext.JobLogs.FromSqlRaw($@"
+                        SELECT * FROM camdaux.job_log
+                        WHERE job_name = '{InventoryChangesIdentity.JobName}'
+                        ORDER BY start_date DESC
+                        LIMIT 1"
+              ).FirstOrDefault();
+
+      // Check the status of the last job log. If the status is "WIP", then return.
+      if (lastJobLog != null && lastJobLog.StatusCd == "WIP")
+      {
+        return true;
+      }
+      return false;
+    }
+
+    private UpdateMpEvalStatusAndReportingFreq(InventoryStatusLog inventoryStatusLog, NpgsqlTransaction sqlTransaction)
+    {
+      _dbContext.CreateTextCommand(
+          "CALL camdecmpswks.update_mp_eval_status_and_reporting_freq(par_V_UNIT_ID, par_V_DATA_TYPE_CD);",
+          sqlTransaction
+      );
+
+      _dbContext.AddInputParameter("par_V_UNIT_ID", inventoryStatusLog.UnitId);
+      _dbContext.AddInputParameter("par_V_DATA_TYPE_CD", inventoryStatusLog.DataTypeCd);
+      _dbContext.ExecuteNonQuery();
+    }
+
+    public static JobKey WithInventoryChangesKey()
+    {
+      return new JobKey(InventoryChangesIdentity.JobName, InventoryChangesIdentity.Group);
+    }
+
+    public static TriggerKey WithInventoryChangesTriggerKey()
+    {
+      return new TriggerKey(InventoryChangesIdentity.TriggerName, InventoryChangesIdentity.Group);
+    }
+
+    public static IJobDetail WithInventoryChangesJobDetail()
+    {
+      return JobBuilder.Create<InventoryChanges>()
+          .WithIdentity(WithInventoryChangesKey())
+          .WithDescription(InventoryChangesIdentity.JobDescription)
+          .Build();
+    }
+
+    public static TriggerBuilder WithInventoryChangesCronSchedule(string cronExpression)
+    {
+      return TriggerBuilder.Create()
+          .WithIdentity(WithInventoryChangesTriggerKey())
+          .WithDescription(InventoryChangesIdentity.TriggerDescription)
+          .WithSchedule(CronScheduleBuilder.CronSchedule(cronExpression).InTimeZone(Utils.getCurrentEasternZone()));
+    }
+  }
 }

--- a/admin/Models/InventoryChangesJobLogAdditionalDetails.cs
+++ b/admin/Models/InventoryChangesJobLogAdditionalDetails.cs
@@ -1,7 +1,7 @@
 namespace Epa.Camd.Quartz.Scheduler.Models
 {
-    public class InventoryChangesJobLogAdditionalDetails
-    {
-        public int LastProcessedInventoryStatusLogId { get; set; }
-    }
+  public class InventoryChangesJobLogAdditionalDetails
+  {
+    public int LastProcessedInventoryStatusLogId { get; set; }
+  }
 }

--- a/admin/Models/InventoryChangesJobLogAdditionalDetails.cs
+++ b/admin/Models/InventoryChangesJobLogAdditionalDetails.cs
@@ -1,0 +1,7 @@
+namespace Epa.Camd.Quartz.Scheduler.Models
+{
+    public class InventoryChangesJobLogAdditionalDetails
+    {
+        public int LastProcessedInventoryStatusLogId { get; set; }
+    }
+}

--- a/admin/Models/InventoryStatusLog.cs
+++ b/admin/Models/InventoryStatusLog.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 namespace Epa.Camd.Quartz.Scheduler.Models
 {
   [Table("inventory_status_log", Schema = "camdaux")]
-  public class JobLog
+  public class InventoryStatusLog
   {
     [Key]
     [Column("inventory_status_log_id")]

--- a/admin/Models/InventoryStatusLog.cs
+++ b/admin/Models/InventoryStatusLog.cs
@@ -4,26 +4,26 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Epa.Camd.Quartz.Scheduler.Models
 {
-    [Table("inventory_status_log", Schema = "camdaux")]
-    public class JobLog
-    {
-        [Key]
-        [Column("inventory_status_log_id")]
-        public int InventoryStatusLogId { get; set; }
+  [Table("inventory_status_log", Schema = "camdaux")]
+  public class JobLog
+  {
+    [Key]
+    [Column("inventory_status_log_id")]
+    public int InventoryStatusLogId { get; set; }
 
-        [Column("fac_id")]
-        public int FacId { get; set; }
+    [Column("fac_id")]
+    public int FacId { get; set; }
 
-        [Column("unit_id")]
-        public int UnitId { get; set; }
+    [Column("unit_id")]
+    public int UnitId { get; set; }
 
-        [Column("data_type_cd")]
-        public string DataTypeCd { get; set; }
+    [Column("data_type_cd")]
+    public string DataTypeCd { get; set; }
 
-        [Column("userid")]
-        public string UserId { get; set; }
+    [Column("userid")]
+    public string UserId { get; set; }
 
-        [Column("last_updated")]
-        public DateTime LastUpdated { get; set; }
-    }
+    [Column("last_updated")]
+    public DateTime LastUpdated { get; set; }
+  }
 }

--- a/admin/Models/InventoryStatusLog.cs
+++ b/admin/Models/InventoryStatusLog.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Epa.Camd.Quartz.Scheduler.Models
+{
+    [Table("inventory_status_log", Schema = "camdaux")]
+    public class JobLog
+    {
+        [Key]
+        [Column("inventory_status_log_id")]
+        public int InventoryStatusLogId { get; set; }
+
+        [Column("fac_id")]
+        public int FacId { get; set; }
+
+        [Column("unit_id")]
+        public int UnitId { get; set; }
+
+        [Column("data_type_cd")]
+        public string DataTypeCd { get; set; }
+
+        [Column("userid")]
+        public string UserId { get; set; }
+
+        [Column("last_updated")]
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/admin/Models/NpgSqlContext.cs
+++ b/admin/Models/NpgSqlContext.cs
@@ -10,6 +10,7 @@ using Quartz;
 using Epa.Camd.Quartz.Scheduler.Jobs;
 
 using Npgsql;
+using NpgsqlTypes;
 
 namespace Epa.Camd.Quartz.Scheduler.Models
 {
@@ -196,12 +197,25 @@ namespace Epa.Camd.Quartz.Scheduler.Models
       var connectionString = this.Database.GetConnectionString();
       var connection = new NpgsqlConnection(connectionString);
 
+      var command = ExecuteProcedure(name, parameters, connection);
+
+      connection.Close();
+
+      return command;
+    }
+
+    public NpgsqlCommand ExecuteProcedure(string name, List<NpgsqlParameter> parameters, NpgsqlConnection connection, NpgsqlTransaction transaction = null)
+    {
       if (connection.State != ConnectionState.Open)
         connection.Open();
 
       var command = connection.CreateCommand();
       command.CommandText = name;
       command.CommandType = CommandType.StoredProcedure;
+      if (transaction != null)
+      {
+        command.Transaction = transaction;
+      }
 
       foreach (var param in parameters)
       {
@@ -209,12 +223,11 @@ namespace Epa.Camd.Quartz.Scheduler.Models
       }
 
       command.ExecuteNonQuery();
-      connection.Close();
 
       return command;
     }
 
-    public NpgsqlParameter CreateParameter(string name, string value, NpgsqlTypes.NpgsqlDbType type, System.Data.ParameterDirection direction)
+    public NpgsqlParameter CreateParameter(string name, string value, NpgsqlDbType type, ParameterDirection direction)
     {
       object oValue = value;
       if (string.IsNullOrEmpty(value))

--- a/admin/Models/NpgSqlContext.cs
+++ b/admin/Models/NpgSqlContext.cs
@@ -23,6 +23,7 @@ namespace Epa.Camd.Quartz.Scheduler.Models
     public DbSet<JobLog> JobLogs {get; set; }
     public DbSet<ReportingPeriod> ReportingPeriods {get; set; }
     public DbSet<BulkFileLog> BulkFileLogs {get; set; }
+    public DbSet<InventoryStatusLog> InventoryStatusLogs {get; set; }
 
     public DbSet<SubmissionSet> SubmissionSet {get; set; }
 

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -123,6 +123,7 @@ namespace Epa.Camd.Quartz.Scheduler
       SubmissionWindowProcessQueue.RegisterWithQuartz(services);
       SubmissionReminderProcessQueue.RegisterWithQuartz(services);
       SubmissionJobQueue.RegisterWithQuartz(services);
+      InventoryChanges.RegisterWithQuartz(services);
 
       services.AddTransient<CheckEngineEvaluationListener>(); //DI for CheckEngineListener
       CheckEngineEvaluationListener.ServiceCollection = services; // Set service collection of the listener
@@ -178,6 +179,7 @@ namespace Epa.Camd.Quartz.Scheduler
       await SubmissionWindowProcessQueue.ScheduleWithQuartz(scheduler, app);
       await EmailQueue.ScheduleWithQuartz(scheduler, app);
       await SubmissionJobQueue.ScheduleWithQuartz(scheduler, app);
+      await InventoryChanges.ScheduleWithQuartz(scheduler, app);
 
       //Schedule Listeners
       await CheckEngineEvaluationListener.ScheduleWithQuartz(scheduler);

--- a/easey-quartz-scheduler.sln
+++ b/easey-quartz-scheduler.sln
@@ -1,0 +1,127 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34701.34
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "easey-job-scheduler", "admin\easey-job-scheduler.csproj", "{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckEngineRunner", "CheckEngine\CheckEngineRunner\CheckEngineRunner.csproj", "{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckEngine", "CheckEngine\CheckEngine\CheckEngine.csproj", "{24F5B1E2-C322-44C5-A341-D13B5E84E34D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SilkierQuartz", "Quartz\SilkierQuartz\SilkierQuartz.csproj", "{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestingPlatform", "CheckEngine\CheckEngine\TestingPlatform.csproj", "{1DFB2335-0EDE-4E8A-AE06-C00621A21728}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckParameters", "CheckEngine\CheckParameters\CheckParameters.csproj", "{5ADB77B4-273E-4339-B774-23589281E798}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DM", "CheckEngine\DM\DM.csproj", "{BAE7B245-1C4D-4E4F-A557-6814913251F6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DatabaseAccess", "CheckEngine\DatabaseAccess\DatabaseAccess.csproj", "{C1469DC1-17E9-47C8-AA46-7B6472762488}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EcmpsCommon", "CheckEngine\EcmpsCommon\EcmpsCommon.csproj", "{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Emissions", "CheckEngine\Emissions\Emissions.csproj", "{4E7C6118-E310-446A-8F62-8B6A4564AB22}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Import", "CheckEngine\Import\Import.csproj", "{D3DD7841-9D1E-4A69-849F-E9012B96B74F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LME", "CheckEngine\LME\LME.csproj", "{85C431B2-076C-4B3B-B88E-0B238F406C1A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonitorPlan", "CheckEngine\MonitorPlan\MonitorPlan.csproj", "{DCEC4ACB-878A-40F0-9A34-940F33A1845C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QA", "CheckEngine\QA\QA.csproj", "{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TypeUtilities", "CheckEngine\TypeUtilities\TypeUtilities.csproj", "{B2D2C46B-5910-4F09-8C21-7EA025C35756}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTest", "CheckEngine\UnitTest\UnitTest.csproj", "{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Logger", "Logger\Logger.csproj", "{5AD067BC-D847-4E05-AAD9-986909E73AB6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quartz.Plugins.RecentHistory", "Quartz\Quartz.Plugins.RecentHistory\Quartz.Plugins.RecentHistory.csproj", "{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C71757B8-B857-4070-88BA-2AEF1E886641}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Related Issues:

- [#5576](https://github.com/US-EPA-CAMD/easey-ui/issues/5576)

## Main Changes:

- Added an `InventoryChanges` job that watches records in the _camdaux.inventory_status_log_ table and calls the _camdecmpswks.update_mp_eval_status_and_reporting_freq_ with the required parameters when records are added.
  - In each run of the job, the runner will fetch all _inventory_status_log_ rows that have not yet been processed, and process them sequentially **in a transaction**. Since they are processed sequentially, it could have been implemented in a way that allows partial processing without the transaction, but I felt that this would muddy the exit status of the job log.
