### PR TITLE
Feature/6375 evaluation queue additional fields

### DIFF
--- a/admin/Jobs/CheckEngineEvaluation.cs
+++ b/admin/Jobs/CheckEngineEvaluation.cs
@@ -73,6 +73,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       Evaluation evalRecord = _dbContext.Evaluations.Find(Int64.Parse(id));
 
       evalRecord.StatusCode = "WIP";
+      evalRecord.StartedTime = DateTime.Now;
       _dbContext.Evaluations.Update(evalRecord);
       _dbContext.SaveChanges();
 
@@ -83,7 +84,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       string monPlanConfig = dataMap.GetString("Configuration");
       string userId = dataMap.GetString("UserId");
       string userEmail = dataMap.GetString("UserEmail");
-      string submittedOn = dataMap.GetString("SubmittedOn");
+      string queuedTime = dataMap.GetString("QueuedTime");
 
       try
       {
@@ -99,7 +100,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
           new LogVariable("Configuration", monPlanConfig),
           new LogVariable("User Id", userId),
           new LogVariable("User Email", userEmail),
-          new LogVariable("Submitted On", submittedOn)
+          new LogVariable("Queued Time", queuedTime)
         );
 
         string dllPath = Configuration["EASEY_QUARTZ_SCHEDULER_CHECK_ENGINE_DLL_PATH"];
@@ -284,6 +285,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         // Update our queued record
         evalRecord.StatusCode = "COMPLETE";
+        evalRecord.CompletedTime = DateTime.Now;
         evalRecord.EvalStatusCode = evaluationStatus;
         _dbContext.Evaluations.Update(evalRecord);
         _dbContext.SaveChanges();
@@ -296,6 +298,8 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         evalRecord.Details = JsonConvert.SerializeObject(ex);
 
         evalRecord.StatusCode = "ERROR";
+        evalRecord.Note = ex.Message;
+        evalRecord.NoteTime = DateTime.Now;
         _dbContext.Evaluations.Update(evalRecord);
         _dbContext.SaveChanges();
 
@@ -391,7 +395,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       string monPlanConfig,
       string userId,
       string userEmail,
-      DateTime submittedOn,
+      DateTime queuedTime,
       string testSumId,
       string qaCertEventId,
       string teeId,
@@ -416,7 +420,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         .UsingJobData("Configuration", monPlanConfig)
         .UsingJobData("UserId", userId)
         .UsingJobData("UserEmail", userEmail)        
-        .UsingJobData("SubmittedOn", submittedOn.ToString())
+        .UsingJobData("QueuedTime", queuedTime.ToString())
         .UsingJobData("qaCertId", qaCertEventId)
         .UsingJobData("testExtensionExemption", teeId)
         .UsingJobData("testSumId", testSumId)

--- a/admin/Jobs/EvaluationJobQueue.cs
+++ b/admin/Jobs/EvaluationJobQueue.cs
@@ -78,14 +78,14 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
             SELECT *
             FROM camdecmpsaux.evaluation_queue
             WHERE process_cd = {0} AND status_cd = 'QUEUED'
-            ORDER BY submitted_on", type
+            ORDER BY queued_time", type
           ).ToList();
 
           List<Evaluation> wip = _dbContext.Evaluations.FromSqlRaw(@"
             SELECT *
             FROM camdecmpsaux.evaluation_queue
             WHERE process_cd = {0} AND status_cd = 'WIP'
-            ORDER BY submitted_on", type
+            ORDER BY queued_time", type
           ).ToList();
 
           if(wip.Count < Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_" + type +"_EVALUATIONS"])){
@@ -108,7 +108,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                     es.Config,
                     es.UserId,
                     es.UserEmail,
-                    toSchedule.SubmittedOn,
+                    toSchedule.QueuedTime,
                     toSchedule.TestSumId,
                     toSchedule.QaCertEventId,
                     toSchedule.TeeId,

--- a/admin/Models/Evaluation.cs
+++ b/admin/Models/Evaluation.cs
@@ -4,41 +4,53 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Epa.Camd.Quartz.Scheduler.Models
 {
-	[Table("evaluation_queue", Schema = "camdecmpsaux")]
-	public class Evaluation
-	{
- 		[Key]
-		[Column("evaluation_id")]
- 		public Int64 EvaluationId { get; set; }
+    [Table("evaluation_queue", Schema = "camdecmpsaux")]
+    public class Evaluation
+    {
+        [Key]
+        [Column("evaluation_id")]
+        public Int64 EvaluationId { get; set; }
 
         [Column("evaluation_set_id")]
- 		public string EvaluationSetId { get; set; }
+        public string EvaluationSetId { get; set; }
 
-		[Column("process_cd")]
- 		public string ProcessCode { get; set; }
+        [Column("process_cd")]
+        public string ProcessCode { get; set; }
 
         [Column("test_sum_id")]
- 		public string TestSumId { get; set; }
+        public string TestSumId { get; set; }
 
         [Column("qa_cert_event_id")]
- 		public string QaCertEventId { get; set; }
+        public string QaCertEventId { get; set; }
 
         [Column("test_extension_exemption_id")]
- 		public string TeeId { get; set; }
+        public string TeeId { get; set; }
 
         [Column("rpt_period_id")]
- 		public Int32? RptPeriod { get; set; }
+        public Int32? RptPeriod { get; set; }
 
         [Column("eval_status_cd")]
- 		public string EvalStatusCode { get; set; }
+        public string EvalStatusCode { get; set; }
 
-		[Column("submitted_on")]
- 		public DateTime SubmittedOn { get; set; }
+        [Column("queued_time")]
+        public DateTime QueuedTime { get; set; }
 
-		[Column("status_cd")]
- 		public string StatusCode { get; set; }
+        [Column("status_cd")]
+        public string StatusCode { get; set; }
 
-		[Column("details")]
- 		public string Details { get; set; }
-	}
+        [Column("details")]
+        public string Details { get; set; }
+
+        [Column("started_time")]
+        public DateTime? StartedTime { get; set; }
+
+        [Column("completed_time")]
+        public DateTime? CompletedTime { get; set; }
+
+        [Column("note")]
+        public string Note { get; set; }
+
+        [Column("note_time")]
+        public DateTime? NoteTime { get; set; }
+    }
 }

--- a/easey-quartz-scheduler.sln
+++ b/easey-quartz-scheduler.sln
@@ -1,0 +1,127 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34701.34
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "easey-job-scheduler", "admin\easey-job-scheduler.csproj", "{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckEngineRunner", "CheckEngine\CheckEngineRunner\CheckEngineRunner.csproj", "{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckEngine", "CheckEngine\CheckEngine\CheckEngine.csproj", "{24F5B1E2-C322-44C5-A341-D13B5E84E34D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SilkierQuartz", "Quartz\SilkierQuartz\SilkierQuartz.csproj", "{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestingPlatform", "CheckEngine\CheckEngine\TestingPlatform.csproj", "{1DFB2335-0EDE-4E8A-AE06-C00621A21728}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckParameters", "CheckEngine\CheckParameters\CheckParameters.csproj", "{5ADB77B4-273E-4339-B774-23589281E798}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DM", "CheckEngine\DM\DM.csproj", "{BAE7B245-1C4D-4E4F-A557-6814913251F6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DatabaseAccess", "CheckEngine\DatabaseAccess\DatabaseAccess.csproj", "{C1469DC1-17E9-47C8-AA46-7B6472762488}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EcmpsCommon", "CheckEngine\EcmpsCommon\EcmpsCommon.csproj", "{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Emissions", "CheckEngine\Emissions\Emissions.csproj", "{4E7C6118-E310-446A-8F62-8B6A4564AB22}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Import", "CheckEngine\Import\Import.csproj", "{D3DD7841-9D1E-4A69-849F-E9012B96B74F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LME", "CheckEngine\LME\LME.csproj", "{85C431B2-076C-4B3B-B88E-0B238F406C1A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonitorPlan", "CheckEngine\MonitorPlan\MonitorPlan.csproj", "{DCEC4ACB-878A-40F0-9A34-940F33A1845C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QA", "CheckEngine\QA\QA.csproj", "{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TypeUtilities", "CheckEngine\TypeUtilities\TypeUtilities.csproj", "{B2D2C46B-5910-4F09-8C21-7EA025C35756}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTest", "CheckEngine\UnitTest\UnitTest.csproj", "{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Logger", "Logger\Logger.csproj", "{5AD067BC-D847-4E05-AAD9-986909E73AB6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quartz.Plugins.RecentHistory", "Quartz\Quartz.Plugins.RecentHistory\Quartz.Plugins.RecentHistory.csproj", "{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CCFC9F6-379F-4BEB-B929-5CDD28AA9E5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1360308-ECE4-4DA0-BD8A-44011BE6A6E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24F5B1E2-C322-44C5-A341-D13B5E84E34D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5ADB77B4-273E-4339-B774-23589281E798}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAE7B245-1C4D-4E4F-A557-6814913251F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1469DC1-17E9-47C8-AA46-7B6472762488}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81936B1E-DB82-4081-80B4-EDBE9B4DBC93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E7C6118-E310-446A-8F62-8B6A4564AB22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3DD7841-9D1E-4A69-849F-E9012B96B74F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85C431B2-076C-4B3B-B88E-0B238F406C1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCEC4ACB-878A-40F0-9A34-940F33A1845C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80B60719-46B9-4D6E-B98C-FC8CD1FD4C67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2D2C46B-5910-4F09-8C21-7EA025C35756}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67C04DF0-945F-4CD3-BAF4-4255CA6CBF36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AD067BC-D847-4E05-AAD9-986909E73AB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD000665-A776-4D57-8AEA-09CFB2EDA7D2}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C71757B8-B857-4070-88BA-2AEF1E886641}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Related Issues:

- [#6375](https://github.com/US-EPA-CAMD/easey-ui/issues/6375)

## Main Changes:

- Updated the `EvaluationJobQueue` job to use the renamed `queued_time` column in place of `submitted_on`.
- Updated the `CheckEngineEvaluation` to populate newly added status columns (`started_time`, `completed_time`, `note`, & `note_time`).