### PR TITLE
Feature/6375 evaluation queue

### DIFF
--- a/admin/Jobs/CheckEngineEvaluation.cs
+++ b/admin/Jobs/CheckEngineEvaluation.cs
@@ -73,7 +73,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       Evaluation evalRecord = _dbContext.Evaluations.Find(Int64.Parse(id));
 
       evalRecord.StatusCode = "WIP";
-      evalRecord.StartedTime = DateTime.UtcNow;
+      evalRecord.StartedTime = Utils.getCurrentEasternTime();
       _dbContext.Evaluations.Update(evalRecord);
       _dbContext.SaveChanges();
 
@@ -285,7 +285,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         // Update our queued record
         evalRecord.StatusCode = "COMPLETE";
-        evalRecord.CompletedTime = DateTime.UtcNow;
+        evalRecord.CompletedTime = Utils.getCurrentEasternTime();
         evalRecord.EvalStatusCode = evaluationStatus;
         _dbContext.Evaluations.Update(evalRecord);
         _dbContext.SaveChanges();
@@ -299,7 +299,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         evalRecord.StatusCode = "ERROR";
         evalRecord.Note = ex.Message;
-        evalRecord.NoteTime = DateTime.UtcNow;
+        evalRecord.NoteTime = Utils.getCurrentEasternTime();
         _dbContext.Evaluations.Update(evalRecord);
         _dbContext.SaveChanges();
 


### PR DESCRIPTION
## Related Issues

- [#6375](https://github.com/US-EPA-CAMD/easey-ui/issues/6375)

## Main Changes

- Switched to using a utility function for getting the current time.
  - In a previous PR, I'd switched from `DateTime.Now` to `DateTime.UtcNow`: this is incorrect for a `timestamp without time zone` column that we use to hold EST/EDT timestamps. I haven't determined why `DateTime.Now` didn't work in the first place and the explicit conversion is necessary (as employed in this PR), so this will need to be observed once deployed to Development.
