### PR TITLE
Feature/6096 dotnet buildpack

### DIFF
--- a/CheckEngine/CheckEngine/CheckEngine.cs
+++ b/CheckEngine/CheckEngine/CheckEngine.cs
@@ -51,7 +51,7 @@ namespace ECMPS.Checks.CheckEngine
         //                 string k = System.AppDomain.CurrentDomain.BaseDirectory;
         //                 Console.WriteLine(k);
         //                 System.Diagnostics.Debug.WriteLine(k);
-        //                 //this.CheckEngine("testUser", connectionString, "C:\\Users\\simerahailu\\Documents\\GitHub\\easey-job-scheduler\\MonitorPlan\\obj\\Debug\\netcoreapp6.0\\", "dumpfilePath", 20);
+        //                 //this.CheckEngine("testUser", connectionString, "C:\\Users\\simerahailu\\Documents\\GitHub\\easey-job-scheduler\\MonitorPlan\\obj\\Debug\\net8.0\\", "dumpfilePath", 20);
         //                 //this.RunChecks_MpReport("02022-614W-168CEAA018EA4CBDAE347BE98F95A548", new DateTime(2011, 2, 12), new DateTime(2011, 2, 12), eCheckEngineRunMode.Normal);
         //                 System.Threading.Thread.Sleep(30000);
         //                 break;

--- a/CheckEngine/CheckEngine/CheckEngine.csproj
+++ b/CheckEngine/CheckEngine/CheckEngine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/CheckEngine/TestingPlatform.csproj
+++ b/CheckEngine/CheckEngine/TestingPlatform.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/CheckEngine/CheckEngine/TestingPlatform.csproj
+++ b/CheckEngine/CheckEngine/TestingPlatform.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/CheckEngine/CheckEngineRunner/CheckEngineRunner.csproj
+++ b/CheckEngine/CheckEngineRunner/CheckEngineRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CheckEngine/CheckEngineRunner/Program.cs
+++ b/CheckEngine/CheckEngineRunner/Program.cs
@@ -79,7 +79,7 @@ namespace CheckEngineRunner
                     {
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
 
-                        string dllPath = Path.Combine(baseDir, "MonitorPlan", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
+                        string dllPath = Path.Combine(baseDir, "MonitorPlan", "obj", "Debug", "net8.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal, batchId);
@@ -96,7 +96,7 @@ namespace CheckEngineRunner
                             if (!int.TryParse(rpPeriodIdText, out rptPeriodId)) { rptPeriodId = 0; }
                         }
 
-                        string dllPath = Path.Combine(baseDir, "Emissions", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
+                        string dllPath = Path.Combine(baseDir, "Emissions", "obj", "Debug", "net8.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_EmReport(monPlanId, rptPeriodId, eCheckEngineRunMode.Normal, batchId);
@@ -108,7 +108,7 @@ namespace CheckEngineRunner
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
                         string testSumId = ((args != null) && (args.Length >= 3)) ? args[2] : null;
 
-                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "net8.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
 
@@ -121,7 +121,7 @@ namespace CheckEngineRunner
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
                         string qaCertEventId = ((args != null) && (args.Length >= 3)) ? args[2] : null;
 
-                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "net8.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
 
@@ -133,7 +133,7 @@ namespace CheckEngineRunner
                         string monPlanId = ((args != null) && (args.Length >= 2)) ? args[1] : null;
                         string teeId = ((args != null) && (args.Length >= 3)) ? args[2] : null;
 
-                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "net8.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, CheckEngineRunnerDBCredentials.CheckEngineRunnerDBConnectionStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_QaReport_Tee(teeId, monPlanId, eCheckEngineRunMode.Normal, batchId);
@@ -167,7 +167,7 @@ namespace CheckEngineRunner
             {
                 case "MP":
                     {
-                        string dllPath = Path.Combine(baseDir, "MonitorPlan", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
+                        string dllPath = Path.Combine(baseDir, "MonitorPlan", "obj", "Debug", "net8.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_MpReport(monPlanId, new DateTime(2008, 1, 1), DateTime.Now.AddYears(1), eCheckEngineRunMode.Normal, batchId);
@@ -179,7 +179,7 @@ namespace CheckEngineRunner
                     {
                         string testSumId = dataMap.GetString("otherId");
 
-                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "netcoreapp6.0") + Path.DirectorySeparatorChar;
+                        string dllPath = Path.Combine(baseDir, "QA", "obj", "Debug", "net8.0") + Path.DirectorySeparatorChar;
                         cCheckEngine checkEngine = new cCheckEngine("userId", connStr, connStr, connStr, dllPath, "dumpfilePath", 20);
 
                         bool result = checkEngine.RunChecks_QaReport_Test(testSumId, monPlanId, eCheckEngineRunMode.Normal, batchId);

--- a/CheckEngine/CheckEngineRunner/Program.cs
+++ b/CheckEngine/CheckEngineRunner/Program.cs
@@ -141,6 +141,7 @@ namespace CheckEngineRunner
                     break;
             }
 
+            Console.WriteLine("Check Engine run completed");
             Console.ReadLine();
         }
     }

--- a/CheckEngine/CheckParameters/CheckParameters.csproj
+++ b/CheckEngine/CheckParameters/CheckParameters.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/DM/DM.csproj
+++ b/CheckEngine/DM/DM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/DatabaseAccess/DatabaseAccess.csproj
+++ b/CheckEngine/DatabaseAccess/DatabaseAccess.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/EcmpsCommon/EcmpsCommon.csproj
+++ b/CheckEngine/EcmpsCommon/EcmpsCommon.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/Emissions/Emissions.csproj
+++ b/CheckEngine/Emissions/Emissions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/Import/Import.csproj
+++ b/CheckEngine/Import/Import.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/LME/LME.csproj
+++ b/CheckEngine/LME/LME.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/MonitorPlan/MonitorPlan.csproj
+++ b/CheckEngine/MonitorPlan/MonitorPlan.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/QA/QA.csproj
+++ b/CheckEngine/QA/QA.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/TypeUtilities/TypeUtilities.csproj
+++ b/CheckEngine/TypeUtilities/TypeUtilities.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/CheckEngine/UnitTest/UnitTest.csproj
+++ b/CheckEngine/UnitTest/UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Logger/Logger.csproj
+++ b/Logger/Logger.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Epa.Camd.Logger</RootNamespace>
   </PropertyGroup>
 

--- a/Quartz/Quartz.Plugins.RecentHistory/Quartz.Plugins.RecentHistory.csproj
+++ b/Quartz/Quartz.Plugins.RecentHistory/Quartz.Plugins.RecentHistory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netstandard2.1</TargetFrameworks>
+	<TargetFramework>netstandard2.1</TargetFramework>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Quartz/SilkierQuartz/SilkierQuartz.csproj
+++ b/Quartz/SilkierQuartz/SilkierQuartz.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp6.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -50,7 +50,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp6.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.10" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.10" />

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -16,6 +16,7 @@ using DatabaseAccess;
 using Epa.Camd.Quartz.Scheduler.Jobs;
 using Epa.Camd.Quartz.Scheduler.Models;
 using Epa.Camd.Quartz.Scheduler.Jobs.Listeners;
+using Microsoft.AspNetCore.Http;
 
 namespace Epa.Camd.Quartz.Scheduler
 {
@@ -154,10 +155,10 @@ namespace Epa.Camd.Quartz.Scheduler
       app.UseSilkierQuartz(displayUi: displayFlag);
 
       app.Use(async (context, next) => {
-        context.Response.Headers.Add("Vary", "Origin");
-        context.Response.Headers.Add("Cache-Control", "no-cache, no-store, must-revalidate");
-        context.Response.Headers.Add("Pragma", "no-cache");
-        context.Response.Headers.Add("Expires", "0");
+        context.Response.Headers.Append("Vary", "Origin");
+        context.Response.Headers.Append("Cache-Control", "no-cache, no-store, must-revalidate");
+        context.Response.Headers.Append("Pragma", "no-cache");
+        context.Response.Headers.Append("Expires", "0");
         await next();
       });
 

--- a/admin/easey-job-scheduler.csproj
+++ b/admin/easey-job-scheduler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Epa.Camd.Quartz.Scheduler</RootNamespace>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\CheckEngine\CheckEngine\CheckEngine.csproj" />
     <ProjectReference Include="..\CheckEngine\DatabaseAccess\DatabaseAccess.csproj" />
     <ProjectReference Include="..\CheckEngine\MonitorPlan\MonitorPlan.csproj" />
-	  <ProjectReference Include="..\CheckEngine\QA\QA.csproj" />
+	<ProjectReference Include="..\CheckEngine\QA\QA.csproj" />
     <ProjectReference Include="..\CheckEngine\Emissions\Emissions.csproj" />
     <ProjectReference Include="..\CheckEngine\DM\DM.csproj" />
     <ProjectReference Include="..\CheckEngine\LME\LME.csproj" />

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
     memory: ((memory))
     instances: ((instances))
     buildpacks:
-      - https://github.com/cloudfoundry/dotnet-core-buildpack.git#v2.4.17
+      - dotnet_core_buildpack
     health-check-type: ((healthCheckType))
     env:
       OPTIMIZE_MEMORY: true


### PR DESCRIPTION
## Related Issues:

- [#6096](https://github.com/US-EPA-CAMD/easey-ui/issues/6096)

## Main Changes:

- Updated project files to target .NET 8.0 rather than .NET 6.0.
- Updated the buildpack specifier in the Cloud Foundry manifest to use the latest version.

## NOTE:

To avoid introducing new behavior, I attempted to resolve **new** build warnings or errors **only**.