### PR TITLE
Fix/6056 manually trigger jobs

### DIFF
--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -27,6 +26,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     private readonly NpgSqlContext _dbContext;
     private readonly IConfiguration _configuration;
     private readonly ILogger<DynamicJobScheduler> _logger;
+    private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
     /// Static job configuration for the dynamic job scheduler.
@@ -49,11 +49,12 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// <param name="dbContext">The database context.</param>
     /// <param name="configuration">The application configuration.</param>
     /// <param name="logger">The logger instance.</param>
-    public DynamicJobScheduler(NpgSqlContext dbContext, IConfiguration configuration, ILogger<DynamicJobScheduler> logger)
+    public DynamicJobScheduler(NpgSqlContext dbContext, IConfiguration configuration, ILogger<DynamicJobScheduler> logger, IServiceProvider serviceProvider)
     {
       _dbContext = dbContext;
       _configuration = configuration;
       _logger = logger;
+      _serviceProvider = serviceProvider;
     }
 
     /// <summary>
@@ -120,11 +121,9 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
       try
       {
-        var jobConfigs = await _dbContext.JobConfigurations
-            .ToListAsync();
+        var jobConfigs = _dbContext.JobConfigurations.ToList();
         _logger.LogInformation($"Found {jobConfigs.Count} job configurations");
 
-        var serviceProvider = (IServiceProvider)context.MergedJobDataMap["ServiceProvider"];
         var scheduler = context.Scheduler;
 
         foreach (var jobConfig in jobConfigs)
@@ -134,7 +133,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
             try
             {
               // Schedule the job according to its configured cron expression.
-              await ScheduleJob(scheduler, serviceProvider, jobConfig);
+              await ScheduleJob(scheduler, jobConfig);
 
               if (jobConfig.RunOnce == true)
               {
@@ -159,11 +158,11 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
           {
             try
             {
-              await RemoveJob(scheduler, jobConfig);
+              await UnscheduleJob(scheduler, jobConfig, _logger);
             }
             catch (Exception e)
             {
-              _logger.LogError($"Error removing job {jobConfig.JobName}: {e.Message}");
+              _logger.LogError($"Error unscheduling job {jobConfig.JobName}: {e.Message}");
             }
           }
         }
@@ -205,29 +204,6 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     }
 
     /// <summary>
-    /// Removes a job from the scheduler based on the job configuration.
-    /// </summary>
-    /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="jobConfig">The job configuration.</param>
-    public async Task RemoveJob(IScheduler scheduler, JobConfiguration jobConfig)
-    {
-      JobKey jobKey = CreateJobKey(jobConfig);
-
-      if (await scheduler.CheckExists(jobKey))
-      {
-        bool deleted = await scheduler.DeleteJob(jobKey);
-        if (deleted)
-        {
-          _logger.LogInformation($"Successfully de-scheduled job: {jobConfig.JobName}");
-        }
-        else
-        {
-          _logger.LogWarning($"Failed to remove job: {jobConfig.JobName}. It may not exist or was already removed.");
-        }
-      }
-    }
-
-    /// <summary>
     /// Schedules a job using the provided scheduler, application builder, and logger.
     /// </summary>
     /// <param name="scheduler">The scheduler instance.</param>
@@ -246,13 +222,12 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// Schedules a job using the provided scheduler, service provider, and job configuration.
     /// </summary>
     /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="serviceProvider">The service provider.</param>
     /// <param name="jobConfig">The job configuration.</param>
-    private async Task ScheduleJob(IScheduler scheduler, IServiceProvider serviceProvider, JobConfiguration jobConfig)
+    private async Task ScheduleJob(IScheduler scheduler, JobConfiguration jobConfig)
     {
       await ScheduleJobInternal(scheduler, jobConfig, _logger, (jobType, triggerBuilder) =>
       {
-        var scheduleJobs = serviceProvider.GetService<IEnumerable<IScheduleJob>>();
+        var scheduleJobs = _serviceProvider.GetService<IEnumerable<IScheduleJob>>();
         IJobRegistratorExtensions.UseQuartzJob(scheduleJobs, jobType, triggerBuilder);
       });
     }
@@ -311,7 +286,16 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       IJobDetail jobDetail = await scheduler.GetJobDetail(jobKey);
       if (jobDetail == null)
       {
-        throw new Exception($"Job with key {jobKey.Name} not found.");
+        _logger.LogInformation($"Job with key {jobKey.Name} not found. Adding job to the scheduler.");
+
+        // Create a new job detail.
+        jobDetail = JobBuilder
+          .Create(GetJobType(jobConfig))
+          .WithIdentity(jobKey)
+          .WithDescription(jobConfig.JobDescription)
+          .Build();
+
+        await scheduler.AddJob(jobDetail, replace: true); // Add the job to the scheduler
       }
 
       // Create the trigger to run once, immediately or at a specified time.

--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -89,9 +89,9 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// </summary>
     /// <param name="jobConfig">The job configuration.</param>
     /// <returns>A <see cref="TriggerKey"/> object.</returns>
-    private static TriggerKey CreateTriggerKey(JobConfiguration jobConfig)
+    private static TriggerKey CreateTriggerKey(JobConfiguration jobConfig, bool once = false)
     {
-      return new TriggerKey(jobConfig.TriggerName ?? jobConfig.JobName, jobConfig.JobGroup);
+      return new TriggerKey($"{jobConfig.TriggerName ?? jobConfig.JobName} ({(once ? "once" : "recurring")})", jobConfig.JobGroup);
     }
 
     /// <summary>
@@ -120,38 +120,51 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
       try
       {
-        var jobsToSchedule = await _dbContext.JobConfigurations
-            .Where(j => j.IsActive)
+        var jobConfigs = await _dbContext.JobConfigurations
             .ToListAsync();
-        _logger.LogInformation($"Found {jobsToSchedule.Count} jobs to schedule");
+        _logger.LogInformation($"Found {jobConfigs.Count} job configurations");
 
         var serviceProvider = (IServiceProvider)context.MergedJobDataMap["ServiceProvider"];
         var scheduler = context.Scheduler;
 
-        foreach (var jobConfig in jobsToSchedule)
+        foreach (var jobConfig in jobConfigs)
         {
-          try
+          if (jobConfig.IsActive)
           {
-            // Schedule the job according to its configured cron expression.
-            await ScheduleJob(scheduler, serviceProvider, jobConfig);
-
-            if (jobConfig.RunOnce == true)
+            try
             {
-              var runAt = jobConfig.RunAt;
+              // Schedule the job according to its configured cron expression.
+              await ScheduleJob(scheduler, serviceProvider, jobConfig);
 
-              // Toggle the `RunOnce` flag to prevent the job from running again.
-              jobConfig.RunOnce = false;
-              jobConfig.RunAt = null;
-              _dbContext.JobConfigurations.Update(jobConfig);
-              await _dbContext.SaveChangesAsync();
+              if (jobConfig.RunOnce == true)
+              {
+                var runAt = jobConfig.RunAt;
 
-              // Schedule the job to run once at a specified time.
-              await ScheduleJobOnce(scheduler, CreateJobKey(jobConfig), CreateTriggerKey(jobConfig), runAt);
+                // Toggle the `RunOnce` flag to prevent the job from running again.
+                jobConfig.RunOnce = false;
+                jobConfig.RunAt = null;
+                _dbContext.JobConfigurations.Update(jobConfig);
+                await _dbContext.SaveChangesAsync();
+
+                // Schedule the job to run once at a specified time.
+                await ScheduleJobOnce(scheduler, jobConfig, runAt);
+              }
+            }
+            catch (Exception e)
+            {
+              _logger.LogError($"Error scheduling job {jobConfig.JobName}: {e.Message}");
             }
           }
-          catch (Exception e)
+          else
           {
-            _logger.LogError($"Error scheduling job {jobConfig.JobName}: {e.Message}");
+            try
+            {
+              await RemoveJob(scheduler, jobConfig);
+            }
+            catch (Exception e)
+            {
+              _logger.LogError($"Error removing job {jobConfig.JobName}: {e.Message}");
+            }
           }
         }
       }
@@ -188,6 +201,29 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       foreach (var jobConfig in jobs)
       {
         RegisterJob(services, jobConfig);
+      }
+    }
+
+    /// <summary>
+    /// Removes a job from the scheduler based on the job configuration.
+    /// </summary>
+    /// <param name="scheduler">The scheduler instance.</param>
+    /// <param name="jobConfig">The job configuration.</param>
+    public async Task RemoveJob(IScheduler scheduler, JobConfiguration jobConfig)
+    {
+      JobKey jobKey = CreateJobKey(jobConfig);
+
+      if (await scheduler.CheckExists(jobKey))
+      {
+        bool deleted = await scheduler.DeleteJob(jobKey);
+        if (deleted)
+        {
+          _logger.LogInformation($"Successfully de-scheduled job: {jobConfig.JobName}");
+        }
+        else
+        {
+          _logger.LogWarning($"Failed to remove job: {jobConfig.JobName}. It may not exist or was already removed.");
+        }
       }
     }
 
@@ -232,7 +268,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     {
       if (string.IsNullOrEmpty(jobConfig.CronExpression))
       {
-        Console.WriteLine($"Job {jobConfig.JobName} has no cron expression and will not be scheduled");
+        await UnscheduleJob(scheduler, jobConfig);
         return;
       }
 
@@ -264,11 +300,13 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// Schedules a job to run once, immediately or at a specified time.
     /// </summary>
     /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="jobKey">The job key.</param>
-    /// <param name="triggerKey">The trigger key.</param>
+    /// <param name="jobConfig">The job configuration.</param>
     /// <param name="runAt">The time to run the job, or null to run immediately.</param>
-    private async Task ScheduleJobOnce(IScheduler scheduler, JobKey jobKey, TriggerKey triggerKey, DateTime? runAt = null)
+    private async Task ScheduleJobOnce(IScheduler scheduler, JobConfiguration jobConfig, DateTime? runAt = null)
     {
+      JobKey jobKey = CreateJobKey(jobConfig);
+      TriggerKey triggerKey = CreateTriggerKey(jobConfig, once: true);
+
       // Retrieve the job detail using the JobKey.
       IJobDetail jobDetail = await scheduler.GetJobDetail(jobKey);
       if (jobDetail == null)
@@ -295,13 +333,43 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         _logger.LogInformation($"Scheduling job {jobKey.Name} to run immediately");
       }
 
-      // Schedule the job with the one-time trigger
-      await scheduler.ScheduleJob(jobDetail, triggerBuilder.Build());
+      if (await scheduler.CheckExists(triggerKey))
+      {
+        await scheduler.RescheduleJob(triggerKey, triggerBuilder.Build());
+      }
+      else
+      {
+        // Schedule the job with the one-time trigger
+        await scheduler.ScheduleJob(jobDetail, triggerBuilder.Build());
+      }
     }
 
     public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app)
     {
       await ScheduleJob(scheduler, app, s_jobConfig);
+    }
+
+    /// <summary>
+    /// Unschedules a job from the scheduler based on the job configuration.
+    /// </summary>
+    /// <param name="scheduler">The scheduler instance.</param>
+    /// <param name="jobConfig">The job configuration.</param>
+    private static async Task UnscheduleJob(IScheduler scheduler, JobConfiguration jobConfig)
+    {
+      TriggerKey triggerKey = CreateTriggerKey(jobConfig);
+
+      if (await scheduler.CheckExists(triggerKey))
+      {
+        bool unscheduled = await scheduler.UnscheduleJob(triggerKey);
+        if (unscheduled)
+        {
+          Console.WriteLine($"Successfully removed trigger for job: {jobConfig.JobName}");
+        }
+        else
+        {
+          Console.WriteLine($"Failed to remove trigger for job: {jobConfig.JobName}.");
+        }
+      }
     }
   }
 }

--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -234,9 +234,9 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// <param name="app">The application builder.</param>
     /// <param name="logger">The logger instance.</param>
     /// <param name="jobConfig">The job configuration.</param>
-    private static async Task ScheduleJob(IScheduler scheduler, IApplicationBuilder app, JobConfiguration jobConfig)
+    private static async Task ScheduleJob(IScheduler scheduler, IApplicationBuilder app, JobConfiguration jobConfig, ILogger logger)
     {
-      await ScheduleJobInternal(scheduler, jobConfig, (jobType, triggerBuilder) =>
+      await ScheduleJobInternal(scheduler, jobConfig, logger, (jobType, triggerBuilder) =>
       {
         app.UseQuartzJob(jobType, triggerBuilder);
       });
@@ -250,7 +250,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// <param name="jobConfig">The job configuration.</param>
     private async Task ScheduleJob(IScheduler scheduler, IServiceProvider serviceProvider, JobConfiguration jobConfig)
     {
-      await ScheduleJobInternal(scheduler, jobConfig, (jobType, triggerBuilder) =>
+      await ScheduleJobInternal(scheduler, jobConfig, _logger, (jobType, triggerBuilder) =>
       {
         var scheduleJobs = serviceProvider.GetService<IEnumerable<IScheduleJob>>();
         IJobRegistratorExtensions.UseQuartzJob(scheduleJobs, jobType, triggerBuilder);
@@ -264,11 +264,11 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// <param name="jobConfig">The job configuration.</param>
     /// <param name="logger">The logger instance.</param>
     /// <param name="scheduleAction">The action to schedule the job.</param>
-    private static async Task ScheduleJobInternal(IScheduler scheduler, JobConfiguration jobConfig, Action<Type, TriggerBuilder> scheduleAction)
+    private static async Task ScheduleJobInternal(IScheduler scheduler, JobConfiguration jobConfig, ILogger logger, Action<Type, TriggerBuilder> scheduleAction)
     {
       if (string.IsNullOrEmpty(jobConfig.CronExpression))
       {
-        await UnscheduleJob(scheduler, jobConfig);
+        await UnscheduleJob(scheduler, jobConfig, logger);
         return;
       }
 
@@ -285,14 +285,14 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         )
         {
           await scheduler.RescheduleJob(triggerKey, triggerBuilder.Build());
-          Console.WriteLine($"Rescheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
+          logger.LogInformation($"Rescheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
         }
       }
       else
       {
         var jobType = GetJobType(jobConfig);
         scheduleAction(jobType, triggerBuilder);
-        Console.WriteLine($"Scheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
+        logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
       }
     }
 
@@ -344,9 +344,9 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       }
     }
 
-    public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app)
+    public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app, ILogger logger)
     {
-      await ScheduleJob(scheduler, app, s_jobConfig);
+      await ScheduleJob(scheduler, app, s_jobConfig, logger);
     }
 
     /// <summary>
@@ -354,7 +354,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// </summary>
     /// <param name="scheduler">The scheduler instance.</param>
     /// <param name="jobConfig">The job configuration.</param>
-    private static async Task UnscheduleJob(IScheduler scheduler, JobConfiguration jobConfig)
+    private static async Task UnscheduleJob(IScheduler scheduler, JobConfiguration jobConfig, ILogger logger)
     {
       TriggerKey triggerKey = CreateTriggerKey(jobConfig);
 
@@ -363,11 +363,11 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         bool unscheduled = await scheduler.UnscheduleJob(triggerKey);
         if (unscheduled)
         {
-          Console.WriteLine($"Successfully removed trigger for job: {jobConfig.JobName}");
+          logger.LogInformation($"Successfully removed trigger for job: {jobConfig.JobName}");
         }
         else
         {
-          Console.WriteLine($"Failed to remove trigger for job: {jobConfig.JobName}.");
+          logger.LogWarning($"Failed to remove trigger for job: {jobConfig.JobName}.");
         }
       }
     }

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -16,6 +16,7 @@ using Epa.Camd.Quartz.Scheduler.Jobs;
 using Epa.Camd.Quartz.Scheduler.Models;
 using Epa.Camd.Quartz.Scheduler.Jobs.Listeners;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Epa.Camd.Quartz.Scheduler
 {
@@ -114,9 +115,9 @@ namespace Epa.Camd.Quartz.Scheduler
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-    public async void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    public async void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
     {
-      Console.WriteLine("Configuring Quartz");
+      logger.LogInformation("Configuring Quartz");
 
       if (env.IsDevelopment())
       {
@@ -145,13 +146,13 @@ namespace Epa.Camd.Quartz.Scheduler
         await next();
       });
 
-      Console.WriteLine("Attempting to schedule quartz jobs");
+      logger.LogInformation("Attempting to schedule quartz jobs");
 
       IScheduler scheduler = app.GetScheduler();
 
       BulkDataFile.setScheduler(scheduler);
 
-      await DynamicJobScheduler.ScheduleWithQuartz(scheduler, app);
+      await DynamicJobScheduler.ScheduleWithQuartz(scheduler, app, logger);
 
       //Schedule Listeners
       await CheckEngineEvaluationListener.ScheduleWithQuartz(scheduler);


### PR DESCRIPTION
## Related Issues

- [#6056](https://github.com/US-EPA-CAMD/easey-ui/issues/6056)

## Main Changes

- Updated the `DynamicJobScheduler` so one-time triggers don't interfere with cron triggers.
- Added logic to unschedule jobs that don't have cron expressions or are marked as inactive.
- Switched from using the `System.Console` logger to `ILogger` in the startup file and the dynamic job scheduler's static methods.