### PR TITLE
#6583 Updated Npgsql.EntityFrameworkCore.PostgreSQL version to 9.0.3

### DIFF
--- a/CheckEngine/CheckEngine/CheckEngine.csproj
+++ b/CheckEngine/CheckEngine/CheckEngine.csproj
@@ -15,10 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Quartz" Version="3.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\CheckParameters\CheckParameters.csproj" />
     <ProjectReference Include="..\DatabaseAccess\DatabaseAccess.csproj" />
     <ProjectReference Include="..\EcmpsCommon\EcmpsCommon.csproj" />

--- a/CheckEngine/CheckEngineRunner/CheckEngineRunner.csproj
+++ b/CheckEngine/CheckEngineRunner/CheckEngineRunner.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Quartz" Version="3.5.0" />
   </ItemGroup>
 

--- a/CheckEngine/DatabaseAccess/DatabaseAccess.csproj
+++ b/CheckEngine/DatabaseAccess/DatabaseAccess.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/admin/easey-job-scheduler.csproj
+++ b/admin/easey-job-scheduler.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AWSSDK.S3" Version="3.5.8.3" />
     <PackageReference Include="DotNetEnv" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.1.1" />

--- a/easey-quartz-scheduler.sln
+++ b/easey-quartz-scheduler.sln
@@ -11,8 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckEngine", "CheckEngine\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SilkierQuartz", "Quartz\SilkierQuartz\SilkierQuartz.csproj", "{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestingPlatform", "CheckEngine\CheckEngine\TestingPlatform.csproj", "{1DFB2335-0EDE-4E8A-AE06-C00621A21728}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CheckParameters", "CheckEngine\CheckParameters\CheckParameters.csproj", "{5ADB77B4-273E-4339-B774-23589281E798}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DM", "CheckEngine\DM\DM.csproj", "{BAE7B245-1C4D-4E4F-A557-6814913251F6}"
@@ -61,10 +59,6 @@ Global
 		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3316CAF7-A7CE-46D1-BF0D-F6598D27C3E7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1DFB2335-0EDE-4E8A-AE06-C00621A21728}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5ADB77B4-273E-4339-B774-23589281E798}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5ADB77B4-273E-4339-B774-23589281E798}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5ADB77B4-273E-4339-B774-23589281E798}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
- Changed CheckEngine DatabaseAccess Npgsql.EntityFrameworkCore.PostgreSQL reference version from 6.0 to 9.0.3.
- Changed EASEY-Job_Scheduler Npgsql.EntityFrameworkCore.PostgreSQL reference version from 7.0 to 9.0.3.
- Removed TestingPlatform project from the solution. (Not used and was causing the need for .Net8-Windows instead of just .Net8)
- Removed unused Check Engine Package References.
