### PR TITLE
fix(6056): temporary workaround to get jobs running

### DIFF
--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -337,9 +337,24 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       }
     }
 
-    public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app, ILogger logger)
+    public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app, ILogger logger, NpgSqlContext dbContext)
     {
-      await ScheduleJob(scheduler, app, s_jobConfig, logger);
+      var jobConfigs = dbContext.JobConfigurations.ToList();
+      foreach (var jobConfig in jobConfigs)
+      {
+        try
+        {
+          // Schedule the job according to its configured cron expression.
+          await ScheduleJob(scheduler, app, jobConfig, logger);
+        }
+        catch (Exception e)
+        {
+          logger.LogError($"Error scheduling job {jobConfig.JobName}: {e.Message}");
+        }
+
+      }
+      // FIXME: Disable the scheduling of _this_ job for now while figuring out problems with de- and rescheduling.
+      //await ScheduleJob(scheduler, app, s_jobConfig, logger);
     }
 
     /// <summary>

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -115,7 +115,7 @@ namespace Epa.Camd.Quartz.Scheduler
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-    public async void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
+    public async void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger, NpgSqlContext dbContext)
     {
       logger.LogInformation("Configuring Quartz");
 
@@ -152,7 +152,7 @@ namespace Epa.Camd.Quartz.Scheduler
 
       BulkDataFile.setScheduler(scheduler);
 
-      await DynamicJobScheduler.ScheduleWithQuartz(scheduler, app, logger);
+      await DynamicJobScheduler.ScheduleWithQuartz(scheduler, app, logger, dbContext);
 
       //Schedule Listeners
       await CheckEngineEvaluationListener.ScheduleWithQuartz(scheduler);


### PR DESCRIPTION
## Related Issues:

- [#6056](https://github.com/US-EPA-CAMD/easey-ui/issues/6056)

## Main Changes:

- Implemented a temporary workaround to ensure jobs are scheduled. This disables the cron scheduling of the **`DynamicJobScheduler`** itself: it is only used to initially register and schedule the other jobs. The behavior will, effectively, be as it was before the job was put in place, except the initial configurations of the other jobs will still be drawn from the database.
