### PR TITLE
Fix/6645 timeout errors

### DIFF
--- a/manifest-vars.staging.yml
+++ b/manifest-vars.staging.yml
@@ -5,7 +5,7 @@ healthCheckType: process
 host: easey-stg.app.cloud.gov
 apiGatewayHost: api.epa.gov/easey/staging
 bulkDataS3Bucket: cg-e8f4cca5-5be8-434f-8987-bbdfa072f142
-maxConnectionPool: 75
+maxConnectionPool: 100
 idleTimeout: 30
 connectionTimeout: 30
 commandTimeout: 300

--- a/manifest-vars.test.yml
+++ b/manifest-vars.test.yml
@@ -5,7 +5,7 @@ healthCheckType: port
 host: easey-tst.app.cloud.gov
 apiGatewayHost: api.epa.gov/easey/test
 bulkDataS3Bucket: cg-fceefece-417a-4e3d-8fd4-6943acd8ea55
-maxConnectionPool: 75
+maxConnectionPool: 100
 idleTimeout: 30
 connectionTimeout: 30
 commandTimeout: 300


### PR DESCRIPTION
## Related Issues:

[#6645](https://github.com/US-EPA-CAMD/easey-ui/issues/6645)

## Main Changes:

- Updated the connection timeout and pool size settings to the minimum values necessary to handle large configurations.