### PR TITLE
#6738 Updated Check Session Failed call to use escaped Error Comment,…

### DIFF
--- a/CheckEngine/DatabaseAccess/AuxDBDataContext.cs
+++ b/CheckEngine/DatabaseAccess/AuxDBDataContext.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Epa.Camd.Logger;
+using Npgsql;
 
 namespace ECMPS.Checks.DatabaseAccess
 {
@@ -111,17 +112,19 @@ namespace ECMPS.Checks.DatabaseAccess
         /// <returns>0</returns>
         public int CheckSessionFailed(string chkSessionId, string errorComment, ref System.Nullable<char> result, ref string errorMessage)
         {
-            _logger.LogInformation("Running CheckSessionFailed for session {ChkSessionId}", chkSessionId);
+            _logger.LogInformation("CheckSessionFailed started for session '{ChkSessionId}' and comment '{Comment}'", chkSessionId ?? "null", errorComment ?? "null");
 
             //TODO (EC-3519): Testing Needed
             string resultString = string.Empty;
             List<string> values = new List<string>();
             DataTable AResultTable;
-            string Sql = "select camdecmpswks.check_session_failed('" + chkSessionId + "','" + errorComment + "')";
+            
+            string selectSqlFormat = "select camdecmpswks.check_session_failed( $1, $2 )";
+            NpgsqlParameter[] selectSqlParameters = { new() { Value = chkSessionId }, new() { Value = errorComment } };
 
             try
             {
-                AResultTable = Database.GetDataTable(Sql);
+                AResultTable = Database.GetDataTable(selectSqlFormat, selectSqlParameters);
 
                 foreach (DataRow row in AResultTable.Rows)
                 {
@@ -139,11 +142,11 @@ namespace ECMPS.Checks.DatabaseAccess
                 resultString = values[0];
                 errorMessage = values[1];
 
-                _logger.LogInformation("CheckSessionFailed completed with result: {Result}, error: {Error}", resultString ?? "N/A", errorMessage ?? "N/A");
+                _logger.LogInformation("CheckSessionFailed completed for session '{ChkSessionId}' with result '{Result}' and error: '{Error}'", chkSessionId ?? "(null)", resultString ?? "N/A", errorMessage ?? "N/A");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "CheckSessionFailed failed for session {ChkSessionId}", chkSessionId);
+                _logger.LogError(ex, "CheckSessionFailed failed for session '{ChkSessionId}' and comment '{Comment}'", chkSessionId ?? "null", errorComment ?? "null");
             }
 
             //Database.CreateStoredProcedureCommand("Check.CheckSessionFailed");

--- a/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
+++ b/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
@@ -865,6 +865,65 @@ namespace ECMPS.Checks.DatabaseAccess
         }
 
         /// <summary>
+        /// Gets a Data.DataTable from the supplied SQL Statement
+        /// </summary>
+        /// <param name="selectSqlFormat">The SQL statement to run</param>
+        /// <param name="selectSqlParameters">The ordered list of parameters values for the select SQL.</param>
+        /// <returns>The DataTable result, or null if an error and LastError will be set</returns>
+        public DataTable GetDataTable(string selectSqlFormat, NpgsqlParameter[] selectSqlParameters)
+        {
+            DataTable dtResults = null;
+            NpgsqlDataAdapter adapter = null;
+
+            Debug.Assert(m_sqlConn != null, "m_sqlConn is null.");
+            if (m_sqlConn == null)
+                return null;
+
+            // reset our error flag!
+            m_bInternalError = false;
+
+            try
+            {
+                adapter = new NpgsqlDataAdapter(selectSqlFormat, m_sqlConn);
+                // this defaults to 30 seconds if we don't override it
+                if (adapter.SelectCommand != null)
+                {
+                    adapter.SelectCommand.CommandTimeout = m_nCmdTimeout;
+                    adapter.SelectCommand.Parameters.AddRange(selectSqlParameters);
+                }
+                dtResults = new DataTable();
+                adapter.Fill(dtResults);
+            }
+            catch (PostgresException sqlEx)
+            {
+                Debug.WriteLine(sqlEx.Message);
+                m_sLastError = sqlEx.Message;
+                _LastException = sqlEx;
+
+                // set our error flag!
+                m_bInternalError = true;
+                throw _LastException;
+            }
+            catch (Exception genEx)
+            {
+                Debug.WriteLine(genEx.Message);
+                m_sLastError = genEx.Message;
+                _LastException = genEx;
+
+                // set our error flag!
+                m_bInternalError = true;
+                throw _LastException;
+            }
+            finally
+            {
+                adapter.Dispose();
+                adapter = null;
+            }
+
+            return dtResults;
+        }
+
+        /// <summary>
         /// Get the schema (structure) of a table
         /// </summary>
         /// <param name="sTableName">The table name in question</param>


### PR DESCRIPTION
# Overview

1. Ensured that the call to the camdecmpswks.check_session_failed stored function includes an "escaped" errorComment.
2. Added errorComment to the logging statements for camdecmpswks.check_session_failed.