### PR TITLE
Fix/6682 build warnings

### DIFF
--- a/CheckEngine/CheckEngine/Checks.cs
+++ b/CheckEngine/CheckEngine/Checks.cs
@@ -158,8 +158,6 @@ namespace ECMPS.Checks.CheckEngine
 		/// </summary>
 		public EmGenerationParameters emGenerationParameters;
 
-
-
 		/// <summary>
 		/// reference to mpParams for all current checks
 		/// </summary>

--- a/CheckEngine/CheckEngine/ModcClasses/ModcDataBorders.cs
+++ b/CheckEngine/CheckEngine/ModcClasses/ModcDataBorders.cs
@@ -137,7 +137,7 @@ namespace ECMPS.Checks.CheckEngine
         #region cModcDataBorderItem Class
 
         /// <summary>
-        /// 
+        /// Class to track last and next measured data borders and the missing data count for a location or system.
         /// </summary>
         public class cModcDataBorderItem
         {
@@ -194,7 +194,7 @@ namespace ECMPS.Checks.CheckEngine
             private int FNextRangeCount = 0;
 
             /// <summary>
-            /// 
+            /// The MON_LOC_ID to track.
             /// </summary>
             public string MonLocId
             {
@@ -210,7 +210,7 @@ namespace ECMPS.Checks.CheckEngine
             public string MonSysId { get; private set; }
 
             /// <summary>
-            /// 
+            /// List of flags indicating whether the parent has a particular method of determination code.
             /// </summary>
             public bool[] ModcList
             {
@@ -221,7 +221,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// Flag indicating whether the parent has a border method of determination code.
             /// </summary>
             public bool BorderModc
             {
@@ -229,7 +229,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The quarter of the emission report quarter.
             /// </summary>
             public int CurrentQuarter
             {
@@ -237,7 +237,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The year of the emission report quarter.
             /// </summary>
             public int CurrentYear
             {
@@ -245,7 +245,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// Flag indicating whether the last border was found.
             /// </summary>
             public bool LastFound
             {
@@ -256,7 +256,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The date of the last op hour from supplemental data.
             /// </summary>
             public DateTime LastBorderDate
             {
@@ -267,7 +267,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The hour of the last op hour from supplemental data.
             /// </summary>
             public int LastBorderHour
             {
@@ -278,12 +278,12 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The last adjusted or unadjusted value from supplemental data, usually used when parameter can be derived or monitored.
             /// </summary>
             public decimal LastBorderValue { get; private set; }
 
             /// <summary>
-            /// 
+            /// The last adjusted value from supplemental data.
             /// </summary>
             public decimal LastBorderAdjustedValue
             {
@@ -294,7 +294,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The last unadjusted value from supplemental data.
             /// </summary>
             public decimal LastBorderUnadjustedValue
             {
@@ -305,12 +305,12 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// Flag indicating whether the last item was supplemental data.
             /// </summary>
             public bool LastIsSuppData { get { return FLastIsSuppData; } set { FLastIsSuppData = value; } }
 
             /// <summary>
-            /// 
+            /// The last skip hour count.
             /// </summary>
             public int LastSkipHourCount
             {
@@ -321,7 +321,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The last range count.
             /// </summary>
             public int LastRangeCount
             {
@@ -332,7 +332,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The next border status.
             /// </summary>
             public eBorderStatus NextBorderStatus
             {
@@ -343,7 +343,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The date of the next op hour from supplemental data.
             /// </summary>
             public DateTime NextBorderDate
             {
@@ -354,7 +354,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The hour of the next op hour from supplemental data.
             /// </summary>
             public int NextBorderHour
             {
@@ -365,12 +365,12 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The next adjusted or unadjusted value from supplemental data, usually used when parameter can be derived or monitored.
             /// </summary>
             public decimal NextBorderValue { get; private set; }
 
             /// <summary>
-            /// 
+            /// The next adjusted value from supplemental data.
             /// </summary>
             public decimal NextBorderAdjustedValue
             {
@@ -381,7 +381,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The next unadjusted value from supplemental data.
             /// </summary>
             public decimal NextBorderUnadjustedValue
             {
@@ -392,7 +392,7 @@ namespace ECMPS.Checks.CheckEngine
             }
 
             /// <summary>
-            /// 
+            /// The next range count.
             /// </summary>
             public int NextRangeCount
             {
@@ -566,7 +566,7 @@ namespace ECMPS.Checks.CheckEngine
             #region cModcDataBorderItem Public Methods: For Programmer Testing
 
             /// <summary>
-            /// 
+            /// TestCaseSet
             /// </summary>
             /// <param name="ALastFound"></param>
             /// <param name="ANextBorderStatus"></param>
@@ -606,12 +606,12 @@ namespace ECMPS.Checks.CheckEngine
         #region Private Fields
 
         /// <summary>
-        /// 
+        /// A list of MODC data borders for monitor locations.
         /// </summary>
         public cModcDataBorderItem[] ModcDataBorderLocations;
 
         /// <summary>
-        /// 
+        /// A mapping of monitor locations to their monitor systems' MODC data borders.
         /// </summary>
         public Dictionary<string, cModcDataBorderItem>[] ModcDataBorderLocationSystems;
 

--- a/CheckEngine/CheckParameters/CheckCategory.cs
+++ b/CheckEngine/CheckParameters/CheckCategory.cs
@@ -14,7 +14,7 @@ namespace ECMPS.Checks.Parameters
   {
 
     /// <summary>
-    /// 
+    /// The ILogger instance to use.
     /// </summary>
     protected readonly ILogger _logger;
 

--- a/CheckEngine/CheckParameters/CheckProcess.cs
+++ b/CheckEngine/CheckParameters/CheckProcess.cs
@@ -13,7 +13,7 @@ namespace ECMPS.Checks.Parameters
   {
 
     /// <summary>
-    /// 
+    /// The ILogger instance to use.
     /// </summary>
     protected readonly ILogger _logger;
  

--- a/CheckEngine/DatabaseAccess/AuxDBDataContext.cs
+++ b/CheckEngine/DatabaseAccess/AuxDBDataContext.cs
@@ -255,7 +255,7 @@ namespace ECMPS.Checks.DatabaseAccess
                 resultString = values[1];
                 errorMessage = values[2];
 
-                _logger.LogInformation("CheckSessionInit Created with sessionId: {ChkSessionId}, result: {Result}, error: {Error}", chkSessionId ?? "N/A", errorMessage ?? "N/A");
+                _logger.LogInformation("CheckSessionInit Created with sessionId: {ChkSessionId}, result: {Result}, error: {Error}", chkSessionId ?? "N/A", resultString ?? "N/A", errorMessage ?? "N/A");
             }
             catch (Exception ex)
             {

--- a/CheckEngine/Emissions/EmissionReport/Categories/Other/OperatingHourCategory.cs
+++ b/CheckEngine/Emissions/EmissionReport/Categories/Other/OperatingHourCategory.cs
@@ -20,7 +20,6 @@ namespace ECMPS.Checks.EmissionsReport
     {
 
         #region Constructors
-        public EmParameters emParams;
         public cOperatingHourCategory(cCheckEngine ACheckEngine,
                                       cEmissionsReportProcess AHourlyEmissionsData,
                                       cHourlyConfigurationInitializationCategory AHourlyConfigurationInitializationCategory, ref EmParameters emparams)

--- a/CheckEngine/Emissions/EmissionReport/Categories/SorbentTrap/MatsSorbentTrapAllRowsCategory.cs
+++ b/CheckEngine/Emissions/EmissionReport/Categories/SorbentTrap/MatsSorbentTrapAllRowsCategory.cs
@@ -22,7 +22,6 @@ namespace ECMPS.Checks.EmissionsReport
   {
 
         #region Constructors
-        public EmParameters emParams;
 
         /// <summary>
         /// Creates a category object to represent the category indicated by the passed code, 

--- a/CheckEngine/Emissions/EmissionReport/Checks/AppendixDEStatusChecks.cs
+++ b/CheckEngine/Emissions/EmissionReport/Checks/AppendixDEStatusChecks.cs
@@ -606,7 +606,7 @@ namespace ECMPS.Checks.EmissionsChecks
                         DateTime CertificationCheckDate;
                         CheckExistenceOfValidFuelFlowTest(Category, out ValidFuelFlowTestExistsForEachComponent, out CertificationCheckDate);
 
-                        if (ValidFuelFlowTestExistsForEachComponent && CertificationCheckDate != null)
+                        if (ValidFuelFlowTestExistsForEachComponent)
                         {
                             Category.SetCheckParameter("FF2L_Accuracy_Eligible", true, eParameterDataType.Boolean);
                             Category.SetCheckParameter("FF2L_Accuracy_Check_Date", CertificationCheckDate, eParameterDataType.Date);
@@ -945,7 +945,6 @@ namespace ECMPS.Checks.EmissionsChecks
                     DataRowView CurrentFFRecord = Category.GetCheckParameter("Current_Fuel_Flow_Record").ValueAsDataRowView();
                     string FuelCd = cDBConvert.ToString(CurrentFFRecord["FUEL_CD"]);
                     DataView OpSuppRecs = Category.GetCheckParameter("Operating_Supp_Data_Records_by_Location").ValueAsDataView();
-                    DataView OpSuppRecsFound;
                     sFilterPair[] FilterOpSupp = new sFilterPair[4];
                     FilterOpSupp[0].Set("OP_TYPE_CD", "OPHOURS");
                     FilterOpSupp[1].Set("FUEL_CD", FuelCd);
@@ -1329,7 +1328,7 @@ namespace ECMPS.Checks.EmissionsChecks
                         DateTime CertificationCheckDate;
                         CheckExistenceOfValidFuelFlowTest(Category, out ValidFuelFlowTestExistsForEachComponent, out CertificationCheckDate);
 
-                        if (ValidFuelFlowTestExistsForEachComponent && CertificationCheckDate != null)
+                        if (ValidFuelFlowTestExistsForEachComponent)
                         {
                             Category.SetCheckParameter("FF2L_PEI_Eligible", true, eParameterDataType.Boolean);
                             Category.SetCheckParameter("FF2L_PEI_Check_Date", CertificationCheckDate, eParameterDataType.Date);

--- a/CheckEngine/Emissions/NonOperatingEmissionGeneration/cGenerationProcess.cs
+++ b/CheckEngine/Emissions/NonOperatingEmissionGeneration/cGenerationProcess.cs
@@ -49,12 +49,12 @@ namespace ECMPS.Checks.NonOperatingEmissionGeneration
     /// </summary>
     public cGenerationParameters GenerationParameters { get { return (cGenerationParameters)ProcessParameters; } }
 
-      EmGenerationParameters emGenerationParameters;
+    EmGenerationParameters emGenerationParameters = new EmGenerationParameters();
 
     /// <summary>
     /// The table containing the generated Hrly Op Data rows
     /// </summary>
-        public DataTable HrlyOpDataTable { get; private set; }
+    public DataTable HrlyOpDataTable { get; private set; }
 
     /// <summary>
     /// Indicates whether the migration of generated data should occur.
@@ -84,11 +84,11 @@ namespace ECMPS.Checks.NonOperatingEmissionGeneration
         resultMessage = null;
         result = true;
 
-        cGenerationCategory locationCategory = new cGenerationCategory(this, "EMGENLC",emGenerationParameters);
+        cGenerationCategory locationCategory = new cGenerationCategory(this, "EMGENLC", emGenerationParameters);
         cGenerationCategory locationHourlyCategory = new cGenerationCategory(locationCategory, "EMGENHR", emGenerationParameters);
-                cGenerationCategory locationSummaryCategory = new cGenerationCategory(locationCategory, "EMGENSV", emGenerationParameters);
+        cGenerationCategory locationSummaryCategory = new cGenerationCategory(locationCategory, "EMGENSV", emGenerationParameters);
 
-                if (!locationCategory.InitCheckBands(CheckEngine.DbConnection, ref resultMessage) ||
+        if (!locationCategory.InitCheckBands(CheckEngine.DbConnection, ref resultMessage) ||
             !locationHourlyCategory.InitCheckBands(CheckEngine.DbConnection, ref resultMessage) ||
             !locationSummaryCategory.InitCheckBands(CheckEngine.DbConnection, ref resultMessage))
         {
@@ -393,7 +393,7 @@ namespace ECMPS.Checks.NonOperatingEmissionGeneration
         Checks[52] = (cChecks)Activator.CreateInstanceFrom(checksDllPath + "ECMPS.Checks.Emissions.dll",
                                                            "ECMPS.Checks.NonOperatingEmissionGeneration.cGenerationChecks",
                                                            true, 0, null, arguments, null, null ).Unwrap();
-                Checks[52].emGenerationParameters = emGenerationParameters;
+        Checks[52].emGenerationParameters = emGenerationParameters;
 
         result = true;
       }

--- a/CheckEngine/TypeUtilities/DistinctHourRanges.cs
+++ b/CheckEngine/TypeUtilities/DistinctHourRanges.cs
@@ -289,25 +289,11 @@ namespace ECMPS.Checks.TypeUtilities
             }
             else
             {
-                if (this.Began == null && other.Began == null)
-                    result = 0;
-                else if (this.Began == null)
-                    result = -1;
-                else if (other.Began == null)
-                    result = 1;
-                else
-                    result = this.Began.CompareTo(other.Began);
+                result = this.Began.CompareTo(other.Began);
 
                 if (result == 0)
                 {
-                    if (this.Ended == null && other.Ended == null)
-                        result = 0;
-                    else if (this.Ended == null)
-                        result = 1;
-                    else if (other.Ended == null)
-                        result = -1;
-                    else
-                        result = this.Ended.CompareTo(other.Ended);
+                    result = this.Ended.CompareTo(other.Ended);
                 }
             }
 
@@ -377,8 +363,8 @@ namespace ECMPS.Checks.TypeUtilities
         /// <returns>The string version of the object.</returns>
         public override string ToString()
         {
-            string beganText = (Began != null) ? FormatHour(Began) : "min";
-            string endedText = (Ended != null) ? FormatHour(Ended) : "max";
+            string beganText = FormatHour(Began);
+            string endedText = FormatHour(Ended);
 
             return $"[{beganText}]..[{endedText}]";
         }

--- a/CheckEngine/TypeUtilities/Extensions.cs
+++ b/CheckEngine/TypeUtilities/Extensions.cs
@@ -85,7 +85,7 @@ namespace ECMPS.Checks.TypeUtilities
     /// <returns>Nullable System.DateTime representation of the value</returns>
     public static DateTime? AsDateTime(this cOperatingHour value)
     {
-      if ((value == null) || (value.Date == null))
+      if (value == null)
       {
         return null;
       }
@@ -131,7 +131,7 @@ namespace ECMPS.Checks.TypeUtilities
     /// <returns>Nullable System.DateTime representation of the value</returns>
     public static eHour? AsHour(this cOperatingHour value)
     {
-      if ((value == null) || (value.Date == null))
+      if (value == null)
       {
         return null;
       }

--- a/admin/Jobs/BulkDataFiles/BulkDataFile.cs
+++ b/admin/Jobs/BulkDataFiles/BulkDataFile.cs
@@ -5,7 +5,8 @@ using System.IO;
 using Microsoft.Extensions.Configuration;
 using Amazon.S3.Model;
 using System.Collections.Generic;
-using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using Newtonsoft.Json;
 
 using Amazon;
@@ -28,6 +29,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
     private NpgSqlContext _dbContext = null;
     private readonly ILogger<BulkDataFile> _logger;
+    private readonly HttpClient _httpClient;
 
     public static class Identity
     {
@@ -46,11 +48,12 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       return new JobKey(Identity.JobName, Identity.Group);
     }
 
-    public BulkDataFile(NpgSqlContext dbContext, IConfiguration configuration, ILogger<BulkDataFile> logger)
+    public BulkDataFile(NpgSqlContext dbContext, IConfiguration configuration, ILogger<BulkDataFile> logger, HttpClient httpClient)
     {
       _dbContext = dbContext;
       Configuration = configuration;
       _logger = logger;
+      _httpClient = httpClient;
     }
 
     private async Task<string> getDescription(string dataType, string subType, decimal? year, decimal? quarter, string state, string programCode){
@@ -100,6 +103,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     {
       _logger.LogInformation("Executing BulkDataFiles job");
 
+      string format = (string) context.JobDetail.JobDataMap.Get("format");
       string url =  (string) context.JobDetail.JobDataMap.Get("url");
       string fileName = (string) context.JobDetail.JobDataMap.Get("fileName");
       Guid job_id = (Guid) context.JobDetail.JobDataMap.Get("job_id");
@@ -132,14 +136,17 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         _logger.LogInformation("Stream URL: {Url}", url ?? "null");
 
-        HttpWebRequest myHttpWebRequest = (HttpWebRequest)WebRequest.Create(url);
-        myHttpWebRequest.Headers.Add("x-api-key", Configuration["EASEY_QUARTZ_SCHEDULER_API_KEY"]);
-        myHttpWebRequest.Headers.Add("accept", (string) context.JobDetail.JobDataMap.Get("format"));
-        myHttpWebRequest.Timeout = 1803000;
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("x-api-key", Configuration["EASEY_QUARTZ_SCHEDULER_API_KEY"]);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(format));
 
-        HttpWebResponse myHttpWebResponse = (HttpWebResponse)myHttpWebRequest.GetResponse();
+        using HttpResponseMessage response = await _httpClient.SendAsync(
+          request, HttpCompletionOption.ResponseHeadersRead, context.CancellationToken);
 
-        Stream s = myHttpWebResponse.GetResponseStream();
+        response.EnsureSuccessStatusCode(); // Throws for non-2xx
+
+        using Stream s = await response.Content.ReadAsStreamAsync(context.CancellationToken);
+
         
         List<UploadPartResponse> uploadResponses = new List<UploadPartResponse>();
 
@@ -228,8 +235,6 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         String[] split = fileName.Split("/");
         string name = split[split.Length - 1];
-        
-        myHttpWebResponse.Close();
         
         if(uploadPartNumber != 1 || totalReadBytes > 0){
 

--- a/admin/Jobs/CheckEngineEvaluation.cs
+++ b/admin/Jobs/CheckEngineEvaluation.cs
@@ -19,7 +19,6 @@ using ECMPS.Checks.CheckEngine.Definitions;
 using Newtonsoft.Json;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Microsoft.Extensions.Logging;
 using ECMPS.Definitions.Extensions;
 
 namespace Epa.Camd.Quartz.Scheduler.Jobs
@@ -29,7 +28,6 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     private NpgSqlContext _dbContext = null;
     private IConfiguration Configuration { get; }
     private readonly ILogger<CheckEngineEvaluation> _logger;
-    static SemaphoreSlim semaphore;
 
     public static class Identity
     {
@@ -70,7 +68,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       }
     }
 
-    public Task Execute(IJobExecutionContext context)
+    public async Task Execute(IJobExecutionContext context)
     {
         // Initialize evaluation stages
         List<EvaluationStageDto> evaluationStages = new List<EvaluationStageDto>
@@ -349,7 +347,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                         evalRecord.StatusCode = "PENDING";
                         _dbContext.Evaluations.Update(evalRecord);
                         _dbContext.SaveChanges();
-                        return Task.CompletedTask;
+                        return;
                     }
 
 
@@ -379,7 +377,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                     emissionEvalRecord.EvalStatus = evaluationStatus;
                     _dbContext.EmissionEvaluations.Update(emissionEvalRecord);
 
-                    _dbContext.ExecuteEmissionRefreshProcedure(monitorPlanId, rp.year, rp.quarter);
+                    await _dbContext.ExecuteEmissionRefreshProcedure(monitorPlanId, rp.year, rp.quarter);
 
                     _logger.LogInformation("Checking for remaining EM evaluations");
                     List<Evaluation> remainingEmEvals = _dbContext.Evaluations.FromSqlRaw(@"
@@ -424,7 +422,6 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
             _logger.LogInformation("Evaluation {EvalId} completed successfully with status {Status}", 
                 id, evaluationStatus);
-            return Task.CompletedTask;
         }
         catch (Exception ex)
         {
@@ -443,7 +440,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
             _logger.LogError(ex.ToString());
 
 
-        switch(processCode){ //Reset status codes to EVAL in case of an evaluation error
+            switch(processCode){ //Reset status codes to EVAL in case of an evaluation error
                 case "MP":
                     _logger.LogInformation("Resetting MP evaluation status to EVAL");
                     MonitorPlan mp = _dbContext.MonitorPlans.Find(monitorPlanId);
@@ -488,10 +485,8 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
             }
             _dbContext.SaveChanges();
 
-        // Send the error email
+            // Send the error email
             _ = SendEvaluationErrorEmail(ex.Message, es.SetId, evalRecord.EvaluationId, evaluationStages);
-
-            return Task.FromException(ex);
         }
     }
 

--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -190,14 +190,12 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// Registers all jobs with Quartz based on database configurations.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    /// <param name="dbContext">The database context.</param>
-    public static void RegisterWithQuartz(IServiceCollection services, NpgSqlContext dbContext)
+    /// <param name="jobConfigs">A list of job configurations to register.</param>
+    public static void RegisterWithQuartz(IServiceCollection services, List<JobConfiguration> jobConfigs)
     {
       RegisterJob(services, s_jobConfig);
 
-      var jobs = dbContext.JobConfigurations.ToList();
-
-      foreach (var jobConfig in jobs)
+      foreach (var jobConfig in jobConfigs)
       {
         RegisterJob(services, jobConfig);
       }

--- a/admin/Jobs/EmailQueueJobs/SubmissionReminderQueue.cs
+++ b/admin/Jobs/EmailQueueJobs/SubmissionReminderQueue.cs
@@ -104,19 +104,20 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
           _dbContext.EmailToProcessQueue.Update(process);
 
           /* foreach(string emailTo in facIdToEmails[process.FacId]){
-            EmailToSend es = new EmailToSend();
-
-            es.Context = process.Context;
-            es.StatusCode = "QUEUED";
-            es.TemplateId = process.EventCode;
-            es.ToEmail = emailTo;
-            es.FromEmail = Configuration["EASEY_QUARTZ_SCHEDULER_WINDOW_NOTIFICATION_FROM_EMAIL"];
+            EmailToSend es = new EmailToSend {
+              Context = process.Context,
+              StatusCode = "QUEUED",
+              TemplateId = process.EventCode,
+              ToEmail = emailTo,
+              FromEmail = Configuration["EASEY_QUARTZ_SCHEDULER_WINDOW_NOTIFICATION_FROM_EMAIL"],
+            };
 
             _dbContext.EmailToSend.Add(es);
           } */
         }
         _dbContext.SaveChanges();
 
+        await Task.Yield(); // TODO: Remove this line when the actual email sending logic is implemented
         return;
       }
       catch (Exception e)

--- a/admin/Jobs/EmailQueueJobs/SubmissionWindowQueue.cs
+++ b/admin/Jobs/EmailQueueJobs/SubmissionWindowQueue.cs
@@ -107,19 +107,20 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
           _dbContext.EmailToProcessQueue.Update(process);
 
           /*foreach(string emailTo in facIdToEmails[process.FacId]){
-            EmailToSend es = new EmailToSend();
-
-            es.Context = process.Context;
-            es.StatusCode = "QUEUED";
-            es.TemplateId = process.EventCode;
-            es.ToEmail = emailTo;
-            es.FromEmail = Configuration["EASEY_QUARTZ_SCHEDULER_WINDOW_NOTIFICATION_FROM_EMAIL"];
+            EmailToSend es = new EmailToSend {
+              Context = process.Context,
+              StatusCode = "QUEUED",
+              TemplateId = process.EventCode,
+              ToEmail = emailTo,
+              FromEmail = Configuration["EASEY_QUARTZ_SCHEDULER_WINDOW_NOTIFICATION_FROM_EMAIL"],
+            };
 
             _dbContext.EmailToSend.Add(es);
           }*/
         }
         _dbContext.SaveChanges();
 
+        await Task.Yield(); // TODO: Remove this line when the actual email sending logic is implemented
         return;
       }
       catch (Exception e)

--- a/admin/Jobs/Listeners/CheckEngineEvaluationListener.cs
+++ b/admin/Jobs/Listeners/CheckEngineEvaluationListener.cs
@@ -34,7 +34,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs.Listeners
       _logger = logger;
     }
 
-    public static async Task ScheduleWithQuartz(IScheduler scheduler){
+    public static void ScheduleWithQuartz(IScheduler scheduler){
       CheckEngineEvaluationListener listener = ServiceCollection.BuildServiceProvider().GetService<CheckEngineEvaluationListener>();
       scheduler.ListenerManager.AddJobListener(listener, GroupMatcher<JobKey>.GroupEquals(Constants.QuartzGroups.EVALUATIONS));
     }

--- a/admin/Models/EmailToProcess.cs
+++ b/admin/Models/EmailToProcess.cs
@@ -1,4 +1,5 @@
-using System;
+#nullable enable
+
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -14,34 +15,34 @@ namespace Epa.Camd.Quartz.Scheduler.Models
 		[Column("fac_id")]
  		public decimal FacId { get; set; }
 
-        [Column("email_type")]
- 		public string EmailType { get; set; }
+    [Column("email_type")]
+ 		public required string EmailType { get; set; }
 
 		[Column("event_code")]
- 		public int EventCode { get; set; } 
+ 		public int? EventCode { get; set; } 
 
 		[Column("userid")]
  		public string? UserId { get; set; } 
 
 		[Column("mon_plan_id")]
- 		public string MonPlanId { get; set; } 
+ 		public string? MonPlanId { get; set; } 
 
 		[Column("rpt_period_id")]
- 		public decimal RptPeriodId { get; set; }
+ 		public decimal? RptPeriodId { get; set; }
 
 		[Column("em_sub_access_id")]
- 		public long EmSubAccessId { get; set; }
+ 		public long? EmSubAccessId { get; set; }
 
 		[Column("submission_type")]
- 		public string SubmissionType { get; set; }
+ 		public string? SubmissionType { get; set; }
 
 		[Column("is_mats")]
- 		public System.Nullable<bool> IsMats { get; set; }
+ 		public bool? IsMats { get; set; }
 
 		[Column("context")]
- 		public string Context { get; set; }
+ 		public string? Context { get; set; }
 
 		[Column("status_cd")]
- 		public string StatusCode { get; set; }
+ 		public required string StatusCode { get; set; }
 	}
 }

--- a/admin/Models/EmailToSend.cs
+++ b/admin/Models/EmailToSend.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -11,18 +13,18 @@ namespace Epa.Camd.Quartz.Scheduler.Models
  		public long SendId { get; set; }
 
 		[Column("to_email")]
- 		public string ToEmail { get; set; }
+ 		public string? ToEmail { get; set; }
 
-        [Column("from_email")]
- 		public string FromEmail { get; set; }
+    [Column("from_email")]
+ 		public string? FromEmail { get; set; }
 
 		[Column("template_id")]
- 		public long TemplateId { get; set; } 
+ 		public long? TemplateId { get; set; } 
 
 		[Column("context")]
- 		public string Context { get; set; } 
+ 		public string? Context { get; set; } 
 
 		[Column("status_cd")]
- 		public string StatusCode { get; set; } 
+ 		public required string StatusCode { get; set; } 
 	}
 }

--- a/admin/Models/NpgSqlContext.cs
+++ b/admin/Models/NpgSqlContext.cs
@@ -9,8 +9,6 @@ using System.Threading.Tasks;
 using Npgsql;
 using NpgsqlTypes;
 
-using Microsoft.Extensions.Logging;
-
 namespace Epa.Camd.Quartz.Scheduler.Models
 {
     public class NpgSqlContext : DbContext

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -45,8 +46,21 @@ namespace Epa.Camd.Quartz.Scheduler
         options.UseNpgsql(_connectionString)
       );
 
-      NpgSqlContext dbContext = services.BuildServiceProvider().GetService<NpgSqlContext>();
-      List<CorsOptions> options = dbContext.CorsOptions.ToListAsync<CorsOptions>().Result;
+#pragma warning disable ASP0000 
+      // Ignore warning [ASP0000]:
+      // >
+      // > "Calling 'BuildServiceProvider' from application code results in an additional copy of singleton services being created."
+      // >
+      // We want to access the `NpgSqlContext` here to retrieve the CORS options and job configurations from the database.
+      List<CorsOptions> corsOptions;
+      List<JobConfiguration> jobConfigurations;
+      using (var scope = services.BuildServiceProvider().CreateScope()) // Build a scoped service provider to access the DbContext
+      {
+        NpgSqlContext dbContext = scope.ServiceProvider.GetRequiredService<NpgSqlContext>();
+        corsOptions = dbContext.CorsOptions.ToList();
+        jobConfigurations = dbContext.JobConfigurations.ToList();
+      }
+#pragma warning restore ASP0000
 
       List<string> allowedOrigins = new List<string>();
       List<string> allowedMethods = new List<string>();
@@ -56,7 +70,7 @@ namespace Epa.Camd.Quartz.Scheduler
           allowedOrigins.Add("http://localhost:3000");
       }
 
-      foreach(CorsOptions opts in options){
+      foreach(CorsOptions opts in corsOptions){
         switch(opts.Key){
           case "origin":
             allowedOrigins.Add(opts.Value);
@@ -105,10 +119,17 @@ namespace Epa.Camd.Quartz.Scheduler
       });
 
       services.AddOptions();
+
+      // Inject a configured HttpClient for the `BulkDataFile` job.
+      services.AddHttpClient<BulkDataFile>(client =>
+      {
+          client.Timeout = TimeSpan.FromMilliseconds(1803000);
+      });
+
       
       CheckEngineEvaluation.RegisterWithQuartz(services);
       BulkDataFile.RegisterWithQuartz(services);
-      DynamicJobScheduler.RegisterWithQuartz(services, dbContext);
+      DynamicJobScheduler.RegisterWithQuartz(services, jobConfigurations);
 
       services.AddTransient<CheckEngineEvaluationListener>(); //DI for CheckEngineListener
       CheckEngineEvaluationListener.ServiceCollection = services; // Set service collection of the listener
@@ -155,7 +176,7 @@ namespace Epa.Camd.Quartz.Scheduler
       await DynamicJobScheduler.ScheduleWithQuartz(scheduler, app, logger);
 
       //Schedule Listeners
-      await CheckEngineEvaluationListener.ScheduleWithQuartz(scheduler);
+      CheckEngineEvaluationListener.ScheduleWithQuartz(scheduler);
     }
   }
 }


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6682

## Main Changes:

The majority of warnings were due to missing or incorrect function docstrings. In most cases where code changes were made, I tried to keep the original functionality, but there are a couple places where I believe the original functionality was incorrect:
- In the **`CheckEngineEvaluation`** job, the call to `ExecuteEmissionRefreshProcedure()` was not being awaited, but now is. Consequently, since the enclosing method is now marked as `async`, it cannot return `Task.CompletedTask/Task.fromException(ex)`. The corresponding return value for `Task.FromException(ex)` in an async function is `throw (ex)`, but it's my opinion that the error has already been handled and **we do not want to rethrow it**.
- In the **`cGenerationProcess`** class, the `emGenerationParameters` member was not initialized, but it is now.

### Other Notes:

- In the **`BulkDataFile`** job, the email functionality was upgraded from the deprecated **`HttpWebRequest`** class to the **`HttpClient`** class.
- I chose to suppress the warning "ASP0000: Calling 'BuildServiceProvider' from application code results in an additional copy of singleton services being created" rather than fix the underlying cause. I believe it's not an issue since we use it just for one-off configuration queries during startup. However, I did move it into a scope to make it a bit safer.