### PR TITLE
Now registers with quartz for dynamic scheduling

### DIFF
--- a/admin/Jobs/EmailQueueJobs/ProcessSubmissionReminders.cs
+++ b/admin/Jobs/EmailQueueJobs/ProcessSubmissionReminders.cs
@@ -4,14 +4,30 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using Epa.Camd.Quartz.Scheduler.Models;
+using Microsoft.Extensions.DependencyInjection;
+using SilkierQuartz;
 
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
     public class ProcessSubmissionReminders : BaseEmailProcessor, IJob
     {
+        private static readonly string GROUP = Constants.QuartzGroups.MAINTAINANCE;
+        private static readonly string JOB_NAME = "ProcessSubmissionReminders";
+        private static readonly string JOB_DESCRIPTION = "Sends submission reminder emails.";
+        
         public ProcessSubmissionReminders(NpgSqlContext dbContext, IConfiguration configuration, ILogger<ProcessSubmissionReminders> logger)
             : base(dbContext, configuration, logger)
         {
+        }
+        
+        public static void RegisterWithQuartz(IServiceCollection services)
+        {
+            services.AddQuartzJob<ProcessSubmissionReminders>(WithJobKey(), JOB_DESCRIPTION);
+        }
+        
+        private static JobKey WithJobKey()
+        {
+            return new JobKey(JOB_NAME, GROUP);
         }
 
         protected override string GetEmailTypeForRecipientApi()
@@ -26,7 +42,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         protected override string GetJobName()
         {
-            return "ProcessSubmissionReminders";
+            return JOB_NAME;
         }
 
         public async Task Execute(IJobExecutionContext context)

--- a/admin/Jobs/EmailQueueJobs/ProcessWindowNotifications.cs
+++ b/admin/Jobs/EmailQueueJobs/ProcessWindowNotifications.cs
@@ -4,14 +4,30 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Quartz;
 using Epa.Camd.Quartz.Scheduler.Models;
+using Microsoft.Extensions.DependencyInjection;
+using SilkierQuartz;
 
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
     public class ProcessWindowNotifications : BaseEmailProcessor, IJob
     {
+        private static readonly string GROUP = Constants.QuartzGroups.MAINTAINANCE;
+        private static readonly string JOB_NAME = "ProcessWindowNotifications";
+        private static readonly string JOB_DESCRIPTION = "Sends submission window notification emails.";
+        
         public ProcessWindowNotifications(NpgSqlContext dbContext, IConfiguration configuration, ILogger<ProcessWindowNotifications> logger)
             : base(dbContext, configuration, logger)
         {
+        }
+
+        public static void RegisterWithQuartz(IServiceCollection services)
+        {
+            services.AddQuartzJob<ProcessWindowNotifications>(WithJobKey(), JOB_DESCRIPTION);
+        }
+        
+        private static JobKey WithJobKey()
+        {
+            return new JobKey(JOB_NAME, GROUP);
         }
 
         protected override string GetEmailTypeForRecipientApi()
@@ -26,7 +42,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         protected override string GetJobName()
         {
-            return "ProcessWindowNotifications";
+            return JOB_NAME;
         }
 
         public async Task Execute(IJobExecutionContext context)

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -129,6 +129,8 @@ namespace Epa.Camd.Quartz.Scheduler
       
       CheckEngineEvaluation.RegisterWithQuartz(services);
       BulkDataFile.RegisterWithQuartz(services);
+      ProcessSubmissionReminders.RegisterWithQuartz(services);
+      ProcessWindowNotifications.RegisterWithQuartz(services);
       DynamicJobScheduler.RegisterWithQuartz(services, jobConfigurations);
 
       services.AddTransient<CheckEngineEvaluationListener>(); //DI for CheckEngineListener


### PR DESCRIPTION
These two jobs (ProcessSubmissionReminders and ProcessWindowNotifications) are automatically triggered from the SubmissionWindowManagement job. Based on the existing pattern, they need to be registered during startup for dynamic scheduling. 