### PR TITLE
Fix/6764 evals stuck in PENDING

### DIFF
--- a/admin/Jobs/CheckEngineEvaluation.cs
+++ b/admin/Jobs/CheckEngineEvaluation.cs
@@ -195,6 +195,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                         TestSummary testSummaryRecord = _dbContext.TestSummaries.Find(testId);
                         testSummaryRecord.EvalStatus = "WIP";
                         _dbContext.TestSummaries.Update(testSummaryRecord);
+                        _dbContext.SaveChanges();
 
                         bool listResult = checkEngine.RunChecks_QaReport_Test(testId, monitorPlanId, eCheckEngineRunMode.Normal, es.SetId);
                         _logger.LogInformation("Test summary checks completed with result: {Result}, EvalId: {EvalId}", 
@@ -424,6 +425,8 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                 default:
                     throw new Exception("A Process Code of [MP, QA, EM] is required and was not provided");
             }
+
+            _dbContext.SaveChanges();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6764

## Main Changes:

- Added missing `_dbContext.SaveChanges` statements. Currently, if there are multiple evaluations queued in a set, the subsequent records are not being started after the first completes.