### PR TITLE
Fix/6882 duplicate quartz triggers

### DIFF
--- a/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/AllowanceComplianceBulkDataFiles.cs
@@ -11,8 +11,13 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class AllowanceComplianceBulkDataFiles  : IJob
+  public class AllowanceComplianceBulkDataFiles  : IJob, IJobMetadata<AllowanceComplianceBulkDataFiles>
   {
+    public static string JobName => "Allowance Compliance Bulk Data";
+    public static string JobDescription => "Determine which allowance compliance data needs to be regenerated and schedule BulkDataFile jobs to handle the regen";
+    public static string JobGroup => Constants.QuartzGroups.BULK_DATA;
+    public static string TriggerName => "Allowance Compliance Bulk Data Trigger";
+    public static string TriggerDescription => "Runs yearly to determine if files need to be regenerated based on query results";
 
     private Guid job_id = Guid.NewGuid();
 

--- a/admin/Jobs/BulkDataFiles/AllowanceHoldingsBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/AllowanceHoldingsBulkDataFiles.cs
@@ -9,8 +9,13 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class AllowanceHoldingsBulkDataFiles : IJob
+  public class AllowanceHoldingsBulkDataFiles : IJob, IJobMetadata<AllowanceHoldingsBulkDataFiles>
   {
+    public static string JobName => "Allowance Holdings Bulk Data";
+    public static string JobDescription => "Generate Allowance Holdings and schedule BulkDataFile jobs to handle the regen";
+    public static string JobGroup => Constants.QuartzGroups.BULK_DATA;
+    public static string TriggerName => "Allowance Holdings Bulk Data Trigger";
+    public static string TriggerDescription => "Runs nightly to generate allowance holdings files";
 
     private Guid _jobId = Guid.NewGuid();
     private NpgSqlContext _dbContext = null;

--- a/admin/Jobs/BulkDataFiles/AllowanceTransactionsBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/AllowanceTransactionsBulkDataFiles.cs
@@ -11,8 +11,13 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class AllowanceTransactionsBulkDataFiles : IJob
+  public class AllowanceTransactionsBulkDataFiles : IJob, IJobMetadata<AllowanceTransactionsBulkDataFiles>
   {
+    public static string JobName => "Allowance Transactions Bulk Data";
+    public static string JobDescription => "Determine which allowance transactions need to be regenerated and schedule BulkDataFile jobs to handle the regen";
+    public static string JobGroup => Constants.QuartzGroups.BULK_DATA;
+    public static string TriggerName => "Allowance Transactions Bulk Data Trigger";
+    public static string TriggerDescription => "Runs nightly to determine if files need to be regenerated based on query results";
 
     private Guid job_id = Guid.NewGuid();
 

--- a/admin/Jobs/BulkDataFiles/ApportionedEmissionsBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/ApportionedEmissionsBulkDataFiles.cs
@@ -11,8 +11,14 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class ApportionedEmissionsBulkData : IJob
+  public class ApportionedEmissionsBulkData : IJob, IJobMetadata<ApportionedEmissionsBulkData>
   {
+    public static string JobName => "Apportioned Emissions Bulk Data";
+    public static string JobDescription => "Determine which emissions need to be regenerated and schedule BulkDataFile jobs to handle the regen";
+    public static string JobGroup => Constants.QuartzGroups.BULK_DATA;
+    public static string TriggerName => "Apportioned Emissions Bulk Data Trigger";
+    public static string TriggerDescription => "Runs nightly to determine if files need to be regenerated based on query results or end of reporting quarter";
+
     private Guid job_id = Guid.NewGuid();
 
     private NpgSqlContext _dbContext = null;

--- a/admin/Jobs/BulkDataFiles/BulkDataFilesMaintenance.cs
+++ b/admin/Jobs/BulkDataFiles/BulkDataFilesMaintenance.cs
@@ -13,8 +13,13 @@ using Microsoft.EntityFrameworkCore;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class BulkDataFileMaintenance : IJob
+  public class BulkDataFileMaintenance : IJob, IJobMetadata<BulkDataFileMaintenance>
   {
+    public static string JobName => "Bulk Data File Maintenance";
+    public static string JobDescription => "Run a check on the bulk data file maintenance queue";
+    public static string JobGroup => Constants.QuartzGroups.BULK_DATA;
+    public static string TriggerName => "Bulk Data File Maintenance Trigger";
+    public static string TriggerDescription => "Run nightly and check which files need to get rerun or cleaned up";
 
     private Guid job_id = Guid.NewGuid();
 

--- a/admin/Jobs/BulkDataFiles/EmissionsComplianceBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/EmissionsComplianceBulkDataFiles.cs
@@ -11,8 +11,13 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class EmissionsComplianceBulkDataFiles  : IJob
+  public class EmissionsComplianceBulkDataFiles  : IJob, IJobMetadata<EmissionsComplianceBulkDataFiles>
   {
+    public static string JobName => "Emissions Compliance Bulk Data";
+    public static string JobDescription => "Determine which emissions compliance data needs to be regenerated and schedule BulkDataFile jobs to handle the regen";
+    public static string JobGroup => Constants.QuartzGroups.BULK_DATA;
+    public static string TriggerName => "Emissions Compliance Bulk Data Trigger";
+    public static string TriggerDescription => "Runs nightly to determine if files need to be regenerated based on query results";
 
     private Guid job_id = Guid.NewGuid();
 

--- a/admin/Jobs/BulkDataFiles/FacilityAttributesBulkDataFiles.cs
+++ b/admin/Jobs/BulkDataFiles/FacilityAttributesBulkDataFiles.cs
@@ -11,8 +11,13 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class FacilityAttributesBulkDataFiles : IJob
+  public class FacilityAttributesBulkDataFiles : IJob, IJobMetadata<FacilityAttributesBulkDataFiles>
   {
+    public static string JobName => "Facility Attributes Bulk Data";
+    public static string JobDescription => "Determine which facility attributes need to be regenerated and schedule BulkDataFile jobs to handle the regen";
+    public static string JobGroup => Constants.QuartzGroups.BULK_DATA;
+    public static string TriggerName => "Facility Attributes Bulk Data Trigger";
+    public static string TriggerDescription => "Runs nightly to determine if files need to be regenerated based on query results";
 
     private Guid job_id = Guid.NewGuid();
 

--- a/admin/Jobs/BulkFileJobQueue.cs
+++ b/admin/Jobs/BulkFileJobQueue.cs
@@ -14,8 +14,14 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class BulkFileJobQueue : IJob
+  public class BulkFileJobQueue : IJob, IJobMetadata<BulkFileJobQueue>
   {
+    public static string JobName => "Bulk File Job Queue";
+    public static string JobDescription => "Operates on an interval to determine if files in queue can be triggered.";
+    public static string JobGroup => Constants.QuartzGroups.MAINTAINANCE;
+    public static string TriggerName => "Bulk File Job Queue Trigger";
+    public static string TriggerDescription => "Operate every minute to determine if there are files in queue which can be triggered";
+
     private NpgSqlContext _dbContext = null;
 
     private IConfiguration Configuration { get; }

--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Epa.Camd.Logger;
+using System.Reflection;
 
 using Quartz;
 using SilkierQuartz;
@@ -19,364 +20,485 @@ using Epa.Camd.Quartz.Scheduler.Models;
 
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
-  /// <summary>
-  /// Represents a job scheduler that dynamically schedules or reschedules jobs based on database configurations.
-  /// </summary>
-  [DisallowConcurrentExecution]
-  public class DynamicJobScheduler : IJob
+  public interface IJobMetadata<TJob> where TJob : IJob
   {
-    private readonly NpgSqlContext _dbContext;
-    private readonly IConfiguration _configuration;
-    private readonly ILogger<DynamicJobScheduler> _logger;
-    private readonly IServiceProvider _serviceProvider;
+    static abstract string JobName { get; }
+    static abstract string JobDescription { get; }
+    static abstract string JobGroup { get; }
+    static abstract string TriggerName { get; }
+    static abstract string TriggerDescription { get; }
+  }
 
-    /// <summary>
-    /// Static job configuration for the dynamic job scheduler.
-    /// </summary>
-    private static readonly JobConfiguration s_jobConfig = new JobConfiguration
-    {
-      JobName = "Dynamic Job Scheduler",
-      JobDescription = "Operates on an interval to determine if any new jobs need to be executed, scheduled, or rescheduled",
-      JobGroup = Constants.QuartzGroups.QUARTZ,
-      JobType = "DynamicJobScheduler",
-      TriggerName = "Check job queue every minute",
-      TriggerDescription = "Operate every minute to determine if there are any new jobs to be scheduled or rescheduled",
-      CronExpression = Utils.Configuration["EASEY_QUARTZ_SCHEDULER_DYNAMIC_JOB_SCHEDULER_SCHEDULE"] ?? "0 0/1 * * * ?",
-      IsActive = true,
-    };
+  public class JobDescriptor
+  {
+    // The actual job type
+    public Type JobType { get; init; } = default!;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DynamicJobScheduler"/> class.
-    /// </summary>
-    /// <param name="dbContext">The database context.</param>
-    /// <param name="configuration">The application configuration.</param>
-    /// <param name="logger">The logger instance.</param>
-    public DynamicJobScheduler(NpgSqlContext dbContext, IConfiguration configuration, ILogger<DynamicJobScheduler> logger, IServiceProvider serviceProvider)
-    {
-      _dbContext = dbContext;
-      _configuration = configuration;
-      _logger = logger;
-      _serviceProvider = serviceProvider;
-    }
+    // From IJobMetadata<TJob>
+    public string JobName { get; init; } = default!;
+    public string JobDescription { get; init; } = default!;
+    public string JobGroup { get; init; } = default!;
+    public string TriggerName { get; init; } = default!;
+    public string TriggerDescription { get; init; } = default!;
 
-    /// <summary>
-    /// Creates a new <see cref="JobKey"/> based on the provided job configuration.
-    /// </summary>
-    /// <param name="jobConfig">The job configuration.</param>
-    /// <returns>A <see cref="JobKey"/> object.</returns>
-    private static JobKey CreateJobKey(JobConfiguration jobConfig)
-    {
-      return new JobKey(jobConfig.JobName, jobConfig.JobGroup);
-    }
+    // From JobConfiguration
+    public string CronExpression { get; init; } = default!;
+    public bool IsActive { get; init; }
+    public bool RunOnce { get; init; }
+    public DateTime? RunAt { get; init; }
+  }
 
-    /// <summary>
-    /// Creates a new <see cref="TriggerBuilder"/> based on the provided job configuration.
-    /// </summary>
-    /// <param name="jobConfig">The job configuration.</param>
-    /// <returns>A <see cref="TriggerBuilder"/> object.</returns>
-    /// <exception cref="FormatException">Thrown if the cron expression is invalid.</exception>
-    private static TriggerBuilder CreateTriggerBuilder(JobConfiguration jobConfig)
+  public static class JobDescriptorFactory
+  {
+    public static JobDescriptor Create<TJob>(JobConfiguration jobConfig)
+      where TJob : IJob, IJobMetadata<TJob>
     {
-      if (!CronExpression.IsValidExpression(jobConfig.CronExpression))
+      return new JobDescriptor
       {
-        throw new FormatException($"Invalid cron expression: {jobConfig.CronExpression}");
+        JobType = typeof(TJob),
+        JobName = TJob.JobName,
+        JobDescription = TJob.JobDescription,
+        JobGroup = TJob.JobGroup,
+        TriggerName = TJob.TriggerName,
+        TriggerDescription = TJob.TriggerDescription,
+        CronExpression = jobConfig?.CronExpression ?? string.Empty,
+        IsActive = jobConfig?.IsActive ?? false,
+        RunOnce = jobConfig?.RunOnce ?? false,
+        RunAt = jobConfig?.RunAt ?? null,
+      };
+    }
+
+    public static JobDescriptor Create(Type jobType, JobConfiguration config)
+    {
+      // figure out the IJobMetadata<TJob> interface
+      var metaInterface = jobType.GetInterfaces()
+          .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IJobMetadata<>));
+
+      string jobName = (string)metaInterface.GetProperty("JobName")!.GetValue(null)!;
+      string jobDescription = (string)metaInterface.GetProperty("JobDescription")!.GetValue(null)!;
+      string jobGroup = (string)metaInterface.GetProperty("JobGroup")!.GetValue(null)!;
+      string triggerName = (string)metaInterface.GetProperty("TriggerName")!.GetValue(null)!;
+      string triggerDescription = (string)metaInterface.GetProperty("TriggerDescription")!.GetValue(null)!;
+
+      return new JobDescriptor
+      {
+        JobType = jobType,
+        JobName = jobName,
+        JobDescription = jobDescription,
+        JobGroup = jobGroup,
+        TriggerName = triggerName,
+        TriggerDescription = triggerDescription,
+        CronExpression = config?.CronExpression ?? string.Empty,
+        IsActive = config?.IsActive ?? false,
+        RunOnce = config?.RunOnce ?? false,
+        RunAt = config?.RunAt ?? null,
+      };
+    }
+
+    public static class JobDiscovery
+    {
+      public static IEnumerable<Type> DiscoverJobs(Assembly assembly)
+      {
+        return assembly
+            .GetTypes()
+            .Where(t =>
+                t is { IsClass: true, IsAbstract: false } &&
+                t.GetInterfaces().Any(i =>
+                    i.IsGenericType &&
+                    i.GetGenericTypeDefinition() == typeof(IJobMetadata<>)
+                )
+            );
       }
-      return TriggerBuilder.Create()
-        .WithIdentity(CreateTriggerKey(jobConfig))
-        .WithDescription(jobConfig.TriggerDescription)
-        .WithSchedule(CronScheduleBuilder.CronSchedule(jobConfig.CronExpression).InTimeZone(Utils.getCurrentEasternZone()));
     }
 
-    /// <summary>
-    /// Creates a new <see cref="TriggerKey"/> based on the provided job configuration.
-    /// </summary>
-    /// <param name="jobConfig">The job configuration.</param>
-    /// <returns>A <see cref="TriggerKey"/> object.</returns>
-    private static TriggerKey CreateTriggerKey(JobConfiguration jobConfig, bool once = false)
-    {
-      return new TriggerKey($"{jobConfig.TriggerName ?? jobConfig.JobName} ({(once ? "once" : "recurring")})", jobConfig.JobGroup);
-    }
 
-    /// <summary>
-    /// Retrieves the <see cref="Type"/> of the job specified in the job configuration.
-    /// </summary>
-    /// <param name="jobConfig">The job configuration.</param>
-    /// <returns>The <see cref="Type"/> of the job.</returns>
-    private static Type GetJobType(JobConfiguration jobConfig)
+    public static class JobRegistry
     {
-      return Type.GetType($"Epa.Camd.Quartz.Scheduler.Jobs.{jobConfig.JobType}");
-    }
-
-    /// <summary>
-    /// Executes the dynamic job scheduler logic to schedule or reschedule jobs.
-    /// </summary>
-    /// <param name="context">The job execution context.</param>
-    public async Task Execute(IJobExecutionContext context)
-    {
-      _logger.LogInformation("Starting Dynamic Job Scheduler");
-
-      try
+      public static List<JobDescriptor> BuildRegistry(
+          Assembly assembly,
+          IEnumerable<JobConfiguration> configs)
       {
-        var jobConfigs = _dbContext.JobConfigurations.ToList();
-        _logger.LogInformation($"Found {jobConfigs.Count} job configurations");
+        var jobs = JobDiscovery.DiscoverJobs(assembly);
 
-        var scheduler = context.Scheduler;
+        var factoryMethod = typeof(JobDescriptorFactory)
+            .GetMethod(nameof(JobDescriptorFactory.Create))!;
 
-        foreach (var jobConfig in jobConfigs)
-        {
-          if (jobConfig.IsActive)
+        return jobs
+          .Select(jobType =>
           {
-            try
+            string className = jobType.Name;
+            var config = configs.FirstOrDefault(c => c.JobClass == className);
+
+            // Make Create<jobType>() dynamically
+            var generic = factoryMethod.MakeGenericMethod(jobType);
+            return (JobDescriptor)generic.Invoke(null, new object[] { config })!;
+          })
+          .ToList();
+      }
+    }
+
+
+
+    /// <summary>
+    /// Represents a job scheduler that dynamically schedules or reschedules jobs based on database configurations.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public class DynamicJobScheduler : IJob
+    {
+      private readonly NpgSqlContext _dbContext;
+      private readonly IConfiguration _configuration;
+      private readonly ILogger<DynamicJobScheduler> _logger;
+      private readonly IServiceProvider _serviceProvider;
+
+      /// <summary>
+      /// Static job descriptor for the dynamic job scheduler.
+      /// </summary>
+      private static readonly JobDescriptor s_jobDescriptor = new JobDescriptor
+      {
+        JobName = "Dynamic Job Scheduler",
+        JobDescription = "Operates on an interval to determine if any new jobs need to be executed, scheduled, or rescheduled",
+        JobGroup = Constants.QuartzGroups.QUARTZ,
+        JobType = typeof(DynamicJobScheduler),
+        TriggerName = "Check job queue every minute",
+        TriggerDescription = "Operate every minute to determine if there are any new jobs to be scheduled or rescheduled",
+        CronExpression = Utils.Configuration["EASEY_QUARTZ_SCHEDULER_DYNAMIC_JOB_SCHEDULER_SCHEDULE"] ?? "0 0/1 * * * ?",
+        IsActive = true,
+      };
+
+      /// <summary>
+      /// Initializes a new instance of the <see cref="DynamicJobScheduler"/> class.
+      /// </summary>
+      /// <param name="dbContext">The database context.</param>
+      /// <param name="configuration">The application configuration.</param>
+      /// <param name="logger">The logger instance.</param>
+      public DynamicJobScheduler(NpgSqlContext dbContext, IConfiguration configuration, ILogger<DynamicJobScheduler> logger, IServiceProvider serviceProvider)
+      {
+        _dbContext = dbContext;
+        _configuration = configuration;
+        _logger = logger;
+        _serviceProvider = serviceProvider;
+      }
+
+      /// <summary>
+      /// Creates a new <see cref="JobKey"/> based on the provided job configuration.
+      /// </summary>
+      /// <param name="jobDescriptor">The job metadata and configuration.</param>
+      /// <returns>A <see cref="JobKey"/> object.</returns>
+      private static JobKey CreateJobKey(JobDescriptor jobDescriptor)
+      {
+        return new JobKey(jobDescriptor.JobName, jobDescriptor.JobGroup);
+      }
+
+      /// <summary>
+      /// Creates a new <see cref="TriggerBuilder"/> based on the provided job configuration.
+      /// </summary>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      /// <returns>A <see cref="TriggerBuilder"/> object.</returns>
+      /// <exception cref="FormatException">Thrown if the cron expression is invalid.</exception>
+      private static TriggerBuilder CreateTriggerBuilder(JobDescriptor jobDescriptor)
+      {
+        if (!CronExpression.IsValidExpression(jobDescriptor.CronExpression))
+        {
+          throw new FormatException($"Invalid cron expression: {jobDescriptor.CronExpression}");
+        }
+        return TriggerBuilder.Create()
+          .WithIdentity(CreateTriggerKey(jobDescriptor))
+          .WithDescription(jobDescriptor.TriggerDescription)
+          .WithSchedule(CronScheduleBuilder.CronSchedule(jobDescriptor.CronExpression).InTimeZone(Utils.getCurrentEasternZone()));
+      }
+
+      /// <summary>
+      /// Creates a new <see cref="TriggerKey"/> based on the provided job configuration.
+      /// </summary>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      /// <returns>A <see cref="TriggerKey"/> object.</returns>
+      private static TriggerKey CreateTriggerKey(JobDescriptor jobDescriptor, bool once = false)
+      {
+        return new TriggerKey($"{jobDescriptor.TriggerName ?? jobDescriptor.JobName} ({(once ? "once" : "recurring")})", jobDescriptor.JobGroup);
+      }
+
+      /// <summary>
+      /// Retrieves the <see cref="Type"/> of the job specified in the job configuration.
+      /// </summary>
+      /// <param name="jobConfig">The job configuration.</param>
+      /// <returns>The <see cref="Type"/> of the job.</returns>
+      private static Type GetJobType(JobConfiguration jobConfig)
+      {
+        return Type.GetType($"Epa.Camd.Quartz.Scheduler.Jobs.{jobConfig.JobClass}");
+      }
+
+      /// <summary>
+      /// Executes the dynamic job scheduler logic to schedule or reschedule jobs.
+      /// </summary>
+      /// <param name="context">The job execution context.</param>
+      public async Task Execute(IJobExecutionContext context)
+      {
+        _logger.LogInformation("Starting Dynamic Job Scheduler");
+
+        try
+        {
+          var jobConfigs = _dbContext.JobConfigurations.ToList();
+          _logger.LogInformation($"Found {jobConfigs.Count} job configurations");
+
+          var scheduler = context.Scheduler;
+
+          foreach (var jobConfig in jobConfigs)
+          {
+            JobDescriptor jobDescriptor = JobDescriptorFactory.Create(GetJobType(jobConfig), jobConfig);
+            if (jobDescriptor.JobType == null)
             {
-              // Schedule the job according to its configured cron expression.
-              await ScheduleJob(scheduler, jobConfig);
+              _logger.LogError($"Job type for class {jobConfig.JobClass} not found.");
+              continue;
+            }
 
-              if (jobConfig.RunOnce == true)
+            if (jobConfig.IsActive)
+            {
+              try
               {
-                var runAt = jobConfig.RunAt;
+                // Schedule the job according to its configured cron expression.
+                await ScheduleJob(scheduler, jobDescriptor);
 
-                // Toggle the `RunOnce` flag to prevent the job from running again.
-                jobConfig.RunOnce = false;
-                jobConfig.RunAt = null;
-                _dbContext.JobConfigurations.Update(jobConfig);
-                _dbContext.SaveChanges();
+                if (jobConfig.RunOnce == true)
+                {
+                  var runAt = jobConfig.RunAt;
 
-                // Schedule the job to run once at a specified time.
-                await ScheduleJobOnce(scheduler, jobConfig, runAt);
+                  // Toggle the `RunOnce` flag to prevent the job from running again.
+                  jobConfig.RunOnce = false;
+                  jobConfig.RunAt = null;
+                  _dbContext.JobConfigurations.Update(jobConfig);
+                  _dbContext.SaveChanges();
+
+                  // Schedule the job to run once at a specified time.
+                  await ScheduleJobOnce(scheduler, jobDescriptor, runAt);
+                }
+              }
+              catch (Exception e)
+              {
+                _logger.LogError($"Error scheduling job {jobDescriptor.JobName}: {e.Message}");
               }
             }
-            catch (Exception e)
+            else
             {
-              _logger.LogError($"Error scheduling job {jobConfig.JobName}: {e.Message}");
+              try
+              {
+                await UnscheduleJob(scheduler, jobDescriptor, _logger);
+              }
+              catch (Exception e)
+              {
+                _logger.LogError($"Error unscheduling job {jobDescriptor.JobName}: {e.Message}");
+              }
+            }
+          }
+        }
+        catch (Exception e)
+        {
+          _logger.LogError($"Error in Dynamic Job Scheduler: {e.Message}");
+        }
+
+        _logger.LogInformation("Completed Dynamic Job Scheduler");
+      }
+
+      /// <summary>
+      /// Registers a job with the specified services based on the job configuration.
+      /// </summary>
+      /// <param name="services">The service collection.</param>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      private static void RegisterJob(IServiceCollection services, JobDescriptor jobDescriptor)
+      {
+        ILogger<DynamicJobScheduler> staticLogger = LoggerProvider.GetLogger<DynamicJobScheduler>();
+        var jobType = jobDescriptor.JobType;
+        if (jobType != null)
+        {
+          services.AddQuartzJob(jobType, CreateJobKey(jobDescriptor), jobDescriptor.JobDescription);
+          staticLogger.LogInformation("Registered job: {JobType} with Quartz", jobDescriptor.JobType);
+        }
+      }
+
+      /// <summary>
+      /// Registers all jobs with Quartz based on database configurations.
+      /// </summary>
+      /// <param name="services">The service collection.</param>
+      /// <param name="jobDescriptors">A list of job descriptors to register.</param>
+      public static void RegisterWithQuartz(IServiceCollection services, List<JobDescriptor> jobDescriptors)
+      {
+        RegisterJob(services, s_jobDescriptor);
+
+        foreach (var jobDescriptor in jobDescriptors)
+        {
+          RegisterJob(services, jobDescriptor);
+        }
+      }
+
+      /// <summary>
+      /// Schedules a job using the provided scheduler, application builder, and logger.
+      /// </summary>
+      /// <param name="scheduler">The scheduler instance.</param>
+      /// <param name="app">The application builder.</param>
+      /// <param name="logger">The logger instance.</param>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      private static async Task ScheduleJob(IScheduler scheduler, IApplicationBuilder app, JobDescriptor jobDescriptor, ILogger logger)
+      {
+        await ScheduleJobInternal(scheduler, jobDescriptor, logger, (triggerBuilder) =>
+        {
+          return Task.Run(() => app.UseQuartzJob(jobDescriptor.JobType, triggerBuilder));
+        });
+      }
+
+      /// <summary>
+      /// Schedules a job using the provided scheduler, service provider, and job configuration.
+      /// </summary>
+      /// <param name="scheduler">The scheduler instance.</param>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      private async Task ScheduleJob(IScheduler scheduler, JobDescriptor jobDescriptor)
+      {
+        await ScheduleJobInternal(scheduler, jobDescriptor, _logger, async (triggerBuilder) =>
+        {
+          var scheduleJobs = _serviceProvider.GetService<IEnumerable<IScheduleJob>>();
+          await IJobRegistratorExtensions.UseQuartzJob(scheduleJobs, scheduler, jobDescriptor.JobType, triggerBuilder);
+        });
+      }
+
+      /// <summary>
+      /// Internal method to schedule a job using the specified scheduler, job configuration, logger, and schedule action.
+      /// </summary>
+      /// <param name="scheduler">The scheduler instance.</param>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      /// <param name="logger">The logger instance.</param>
+      /// <param name="scheduleAction">The action to schedule the job.</param>
+      private static async Task ScheduleJobInternal(IScheduler scheduler, JobDescriptor jobDescriptor, ILogger logger, Func<TriggerBuilder, Task> scheduleAction)
+      {
+        if (string.IsNullOrEmpty(jobDescriptor.CronExpression))
+        {
+          // Unschedule the job if the cron expression is empty.
+          await UnscheduleJob(scheduler, jobDescriptor, logger);
+          return;
+        }
+
+        JobKey jobKey = CreateJobKey(jobDescriptor);
+        TriggerKey triggerKey = CreateTriggerKey(jobDescriptor);
+        TriggerBuilder triggerBuilder = CreateTriggerBuilder(jobDescriptor);
+
+        if (await scheduler.CheckExists(jobKey))
+        {
+          if (await scheduler.CheckExists(triggerKey))
+          {
+            // Reschedule if the job's cron expression has changed.
+            ITrigger trigger = await scheduler.GetTrigger(triggerKey);
+            if (
+              trigger is ICronTrigger cronTrigger &&
+              cronTrigger.CronExpressionString != jobDescriptor.CronExpression
+            )
+            {
+              await scheduler.RescheduleJob(triggerKey, triggerBuilder.Build());
+              logger.LogInformation($"Rescheduled {jobKey.Name} with cron expression [{jobDescriptor.CronExpression}]");
             }
           }
           else
           {
-            try
-            {
-              await UnscheduleJob(scheduler, jobConfig, _logger);
-            }
-            catch (Exception e)
-            {
-              _logger.LogError($"Error unscheduling job {jobConfig.JobName}: {e.Message}");
-            }
+            // Schedule the job with the new trigger.
+            await scheduler.ScheduleJob(triggerBuilder.ForJob(jobKey).Build());
+            logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobDescriptor.CronExpression}]");
           }
         }
-      }
-      catch (Exception e)
-      {
-        _logger.LogError($"Error in Dynamic Job Scheduler: {e.Message}");
-      }
-
-      _logger.LogInformation("Completed Dynamic Job Scheduler");
-    }
-
-    /// <summary>
-    /// Registers a job with the specified services based on the job configuration.
-    /// </summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="jobConfig">The job configuration.</param>
-    private static void RegisterJob(IServiceCollection services, JobConfiguration jobConfig)
-    {
-      ILogger<DynamicJobScheduler> staticLogger = LoggerProvider.GetLogger<DynamicJobScheduler>();
-      var jobType = GetJobType(jobConfig);
-      if (jobType != null)
-      {
-        services.AddQuartzJob(jobType, CreateJobKey(jobConfig), jobConfig.JobDescription);
-        staticLogger.LogInformation("Registered job: {JobType} with Quartz", jobConfig.JobType);
-      }
-    }
-
-    /// <summary>
-    /// Registers all jobs with Quartz based on database configurations.
-    /// </summary>
-    /// <param name="services">The service collection.</param>
-    /// <param name="jobConfigs">A list of job configurations to register.</param>
-    public static void RegisterWithQuartz(IServiceCollection services, List<JobConfiguration> jobConfigs)
-    {
-      RegisterJob(services, s_jobConfig);
-
-      foreach (var jobConfig in jobConfigs)
-      {
-        RegisterJob(services, jobConfig);
-      }
-    }
-
-    /// <summary>
-    /// Schedules a job using the provided scheduler, application builder, and logger.
-    /// </summary>
-    /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="app">The application builder.</param>
-    /// <param name="logger">The logger instance.</param>
-    /// <param name="jobConfig">The job configuration.</param>
-    private static async Task ScheduleJob(IScheduler scheduler, IApplicationBuilder app, JobConfiguration jobConfig, ILogger logger)
-    {
-      await ScheduleJobInternal(scheduler, jobConfig, logger, (jobType, triggerBuilder) =>
-      {
-        return Task.Run(() => app.UseQuartzJob(jobType, triggerBuilder));
-      });
-    }
-
-    /// <summary>
-    /// Schedules a job using the provided scheduler, service provider, and job configuration.
-    /// </summary>
-    /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="jobConfig">The job configuration.</param>
-    private async Task ScheduleJob(IScheduler scheduler, JobConfiguration jobConfig)
-    {
-      await ScheduleJobInternal(scheduler, jobConfig, _logger, async (jobType, triggerBuilder) =>
-      {
-        var scheduleJobs = _serviceProvider.GetService<IEnumerable<IScheduleJob>>();
-        await IJobRegistratorExtensions.UseQuartzJob(scheduleJobs, scheduler, jobType, triggerBuilder);
-      });
-    }
-
-    /// <summary>
-    /// Internal method to schedule a job using the specified scheduler, job configuration, logger, and schedule action.
-    /// </summary>
-    /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="jobConfig">The job configuration.</param>
-    /// <param name="logger">The logger instance.</param>
-    /// <param name="scheduleAction">The action to schedule the job.</param>
-    private static async Task ScheduleJobInternal(IScheduler scheduler, JobConfiguration jobConfig, ILogger logger, Func<Type, TriggerBuilder, Task> scheduleAction)
-    {
-      if (string.IsNullOrEmpty(jobConfig.CronExpression))
-      {
-        // Unschedule the job if the cron expression is empty.
-        await UnscheduleJob(scheduler, jobConfig, logger);
-        return;
+        else
+        {
+          // Create a new job detail and schedule the job.
+          await scheduleAction(triggerBuilder);
+          logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobDescriptor.CronExpression}]");
+        }
       }
 
-      JobKey jobKey = CreateJobKey(jobConfig);
-      TriggerKey triggerKey = CreateTriggerKey(jobConfig);
-      TriggerBuilder triggerBuilder = CreateTriggerBuilder(jobConfig);
-
-      if (await scheduler.CheckExists(jobKey))
+      /// <summary>
+      /// Schedules a job to run once, immediately or at a specified time.
+      /// </summary>
+      /// <param name="scheduler">The scheduler instance.</param>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      /// <param name="runAt">The time to run the job, or null to run immediately.</param>
+      private async Task ScheduleJobOnce(IScheduler scheduler, JobDescriptor jobDescriptor, DateTime? runAt = null)
       {
+        JobKey jobKey = CreateJobKey(jobDescriptor);
+        TriggerKey triggerKey = CreateTriggerKey(jobDescriptor, once: true);
+
+        // Retrieve the job detail using the JobKey.
+        IJobDetail jobDetail = await scheduler.GetJobDetail(jobKey);
+        if (jobDetail == null)
+        {
+          _logger.LogInformation($"Job with key {jobKey.Name} not found. Adding job to the scheduler.");
+
+          // Create a new job detail.
+          var jobType = jobDescriptor.JobType;
+          if (jobType == null)
+          {
+            _logger.LogError($"Job type {jobDescriptor.JobType} not found.");
+            return;
+          }
+
+          jobDetail = JobBuilder
+            .Create(jobType)
+            .WithIdentity(jobKey)
+            .WithDescription(jobDescriptor.JobDescription)
+            .StoreDurably(true) // Ensure job persists even without a trigger
+            .Build();
+
+          await scheduler.AddJob(jobDetail, replace: false); // Only add the job if it doesn't exist
+        }
+
+        // Create the trigger to run once, immediately or at a specified time.
+        TriggerBuilder triggerBuilder = TriggerBuilder.Create()
+            .WithIdentity(triggerKey)
+            .WithDescription($"Run once trigger for job {jobKey.Name}");
+
+        if (runAt.HasValue)
+        {
+          // Ensure `runAt` is in Eastern Time.
+          TimeZoneInfo easternZone = Utils.getCurrentEasternZone();
+          DateTimeOffset easternTime = new DateTimeOffset(runAt.Value, easternZone.GetUtcOffset(runAt.Value));
+          triggerBuilder.StartAt(easternTime);
+          _logger.LogInformation($"Scheduling job {jobKey.Name} to run once at {easternTime}");
+        }
+        else
+        {
+          triggerBuilder.StartNow();
+          _logger.LogInformation($"Scheduling job {jobKey.Name} to run immediately");
+        }
+
+        var newTrigger = triggerBuilder.ForJob(jobKey).Build();
+
         if (await scheduler.CheckExists(triggerKey))
         {
-          // Reschedule if the job's cron expression has changed.
-          ITrigger trigger = await scheduler.GetTrigger(triggerKey);
-          if (
-            trigger is ICronTrigger cronTrigger &&
-            cronTrigger.CronExpressionString != jobConfig.CronExpression
-          )
+          await scheduler.RescheduleJob(triggerKey, newTrigger);
+        }
+        else
+        {
+          await scheduler.ScheduleJob(newTrigger);
+        }
+      }
+
+      public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app, ILogger logger)
+      {
+        await ScheduleJob(scheduler, app, s_jobDescriptor, logger);
+      }
+
+      /// <summary>
+      /// Unschedules a job from the scheduler based on the job configuration.
+      /// </summary>
+      /// <param name="scheduler">The scheduler instance.</param>
+      /// <param name="jobDescriptor">The job configuration and metadata.</param>
+      private static async Task UnscheduleJob(IScheduler scheduler, JobDescriptor jobDescriptor, ILogger logger)
+      {
+        TriggerKey triggerKey = CreateTriggerKey(jobDescriptor);
+
+        if (await scheduler.CheckExists(triggerKey))
+        {
+          bool unscheduled = await scheduler.UnscheduleJob(triggerKey);
+          if (unscheduled)
           {
-            await scheduler.RescheduleJob(triggerKey, triggerBuilder.Build());
-            logger.LogInformation($"Rescheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
+            logger.LogInformation($"Successfully removed trigger for job: {jobDescriptor.JobName}");
           }
-        }
-        else
-        {
-          // Schedule the job with the new trigger.
-          await scheduler.ScheduleJob(triggerBuilder.ForJob(jobKey).Build());
-          logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
-        }
-      }
-      else
-      {
-        // Create a new job detail and schedule the job.
-        var jobType = GetJobType(jobConfig);
-        if (jobType == null)
-        {
-          logger.LogError($"Job type {jobConfig.JobType} not found.");
-          return;
-        }
-        await scheduleAction(jobType, triggerBuilder);
-        logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
-      }
-    }
-
-    /// <summary>
-    /// Schedules a job to run once, immediately or at a specified time.
-    /// </summary>
-    /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="jobConfig">The job configuration.</param>
-    /// <param name="runAt">The time to run the job, or null to run immediately.</param>
-    private async Task ScheduleJobOnce(IScheduler scheduler, JobConfiguration jobConfig, DateTime? runAt = null)
-    {
-      JobKey jobKey = CreateJobKey(jobConfig);
-      TriggerKey triggerKey = CreateTriggerKey(jobConfig, once: true);
-
-      // Retrieve the job detail using the JobKey.
-      IJobDetail jobDetail = await scheduler.GetJobDetail(jobKey);
-      if (jobDetail == null)
-      {
-        _logger.LogInformation($"Job with key {jobKey.Name} not found. Adding job to the scheduler.");
-
-        // Create a new job detail.
-        var jobType = GetJobType(jobConfig);
-        if (jobType == null)
-        {
-          _logger.LogError($"Job type {jobConfig.JobType} not found.");
-          return;
-        }
-
-        jobDetail = JobBuilder
-          .Create(jobType)
-          .WithIdentity(jobKey)
-          .WithDescription(jobConfig.JobDescription)
-          .StoreDurably(true) // Ensure job persists even without a trigger
-          .Build();
-
-        await scheduler.AddJob(jobDetail, replace: false); // Only add the job if it doesn't exist
-      }
-
-      // Create the trigger to run once, immediately or at a specified time.
-      TriggerBuilder triggerBuilder = TriggerBuilder.Create()
-          .WithIdentity(triggerKey)
-          .WithDescription($"Run once trigger for job {jobKey.Name}");
-
-      if (runAt.HasValue)
-      {
-        // Ensure `runAt` is in Eastern Time.
-        TimeZoneInfo easternZone = Utils.getCurrentEasternZone();
-        DateTimeOffset easternTime = new DateTimeOffset(runAt.Value, easternZone.GetUtcOffset(runAt.Value));
-        triggerBuilder.StartAt(easternTime);
-        _logger.LogInformation($"Scheduling job {jobKey.Name} to run once at {easternTime}");
-      }
-      else
-      {
-        triggerBuilder.StartNow();
-        _logger.LogInformation($"Scheduling job {jobKey.Name} to run immediately");
-      }
-
-      var newTrigger = triggerBuilder.ForJob(jobKey).Build();
-
-      if (await scheduler.CheckExists(triggerKey))
-      {
-        await scheduler.RescheduleJob(triggerKey, newTrigger);
-      }
-      else
-      {
-        await scheduler.ScheduleJob(newTrigger);
-      }
-    }
-
-    public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app, ILogger logger)
-    {
-      await ScheduleJob(scheduler, app, s_jobConfig, logger);
-    }
-
-    /// <summary>
-    /// Unschedules a job from the scheduler based on the job configuration.
-    /// </summary>
-    /// <param name="scheduler">The scheduler instance.</param>
-    /// <param name="jobConfig">The job configuration.</param>
-    private static async Task UnscheduleJob(IScheduler scheduler, JobConfiguration jobConfig, ILogger logger)
-    {
-      TriggerKey triggerKey = CreateTriggerKey(jobConfig);
-
-      if (await scheduler.CheckExists(triggerKey))
-      {
-        bool unscheduled = await scheduler.UnscheduleJob(triggerKey);
-        if (unscheduled)
-        {
-          logger.LogInformation($"Successfully removed trigger for job: {jobConfig.JobName}");
-        }
-        else
-        {
-          logger.LogWarning($"Failed to remove trigger for job: {jobConfig.JobName}.");
+          else
+          {
+            logger.LogWarning($"Failed to remove trigger for job: {jobDescriptor.JobName}.");
+          }
         }
       }
     }

--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -211,7 +211,12 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     /// <returns>The <see cref="Type"/> of the job.</returns>
     private static Type GetJobType(JobConfiguration jobConfig)
     {
-      return Type.GetType($"Epa.Camd.Quartz.Scheduler.Jobs.{jobConfig.JobClass}");
+      var jobType = Type.GetType($"Epa.Camd.Quartz.Scheduler.Jobs.{jobConfig.JobClass}");
+      if (jobType == null)
+      {
+        throw new ArgumentException($"Job class {jobConfig.JobClass} not found.");
+      }
+      return jobType;
     }
 
     /// <summary>
@@ -231,13 +236,19 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
 
         foreach (var jobConfig in jobConfigs)
         {
-          JobDescriptor jobDescriptor = JobDescriptorFactory.Create(GetJobType(jobConfig));
-          if (jobDescriptor.JobType == null)
+          // Find the job type based on the job class name in the configuration.
+          JobDescriptor jobDescriptor;
+          try
           {
-            _logger.LogError($"Job type for class {jobConfig.JobClass} not found.");
+            jobDescriptor = JobDescriptorFactory.Create(GetJobType(jobConfig));
+          }
+          catch (Exception e)
+          {
+            _logger.LogError($"Error creating job descriptor for class {jobConfig.JobClass}: {e.Message}");
             continue;
           }
 
+          // Schedule or unschedule the job based on its active status.
           if (jobConfig.IsActive)
           {
             try

--- a/admin/Jobs/DynamicJobScheduler.cs
+++ b/admin/Jobs/DynamicJobScheduler.cs
@@ -40,17 +40,11 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
     public string JobGroup { get; init; } = default!;
     public string TriggerName { get; init; } = default!;
     public string TriggerDescription { get; init; } = default!;
-
-    // From JobConfiguration
-    public string CronExpression { get; init; } = default!;
-    public bool IsActive { get; init; }
-    public bool RunOnce { get; init; }
-    public DateTime? RunAt { get; init; }
   }
 
   public static class JobDescriptorFactory
   {
-    public static JobDescriptor Create<TJob>(JobConfiguration jobConfig)
+    public static JobDescriptor Create<TJob>()
       where TJob : IJob, IJobMetadata<TJob>
     {
       return new JobDescriptor
@@ -61,444 +55,447 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         JobGroup = TJob.JobGroup,
         TriggerName = TJob.TriggerName,
         TriggerDescription = TJob.TriggerDescription,
-        CronExpression = jobConfig?.CronExpression ?? string.Empty,
-        IsActive = jobConfig?.IsActive ?? false,
-        RunOnce = jobConfig?.RunOnce ?? false,
-        RunAt = jobConfig?.RunAt ?? null,
       };
     }
 
-    public static JobDescriptor Create(Type jobType, JobConfiguration config)
+    public static JobDescriptor Create(Type jobType)
     {
-      // figure out the IJobMetadata<TJob> interface
+      if (!typeof(IJob).IsAssignableFrom(jobType))
+        throw new ArgumentException($"{jobType} does not implement IJob");
+
+      // Figure out the IJobMetadata<TJob> interface
       var metaInterface = jobType.GetInterfaces()
-          .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IJobMetadata<>));
+          .SingleOrDefault(i => i.IsGenericType &&
+                                i.GetGenericTypeDefinition() == typeof(IJobMetadata<>));
 
-      string jobName = (string)metaInterface.GetProperty("JobName")!.GetValue(null)!;
-      string jobDescription = (string)metaInterface.GetProperty("JobDescription")!.GetValue(null)!;
-      string jobGroup = (string)metaInterface.GetProperty("JobGroup")!.GetValue(null)!;
-      string triggerName = (string)metaInterface.GetProperty("TriggerName")!.GetValue(null)!;
-      string triggerDescription = (string)metaInterface.GetProperty("TriggerDescription")!.GetValue(null)!;
+      if (metaInterface == null)
+        throw new ArgumentException($"{jobType} does not implement IJobMetadata<>");
 
-      return new JobDescriptor
+      var factoryMethod = typeof(JobDescriptorFactory)
+          .GetMethods()
+          .Single(m => m.Name == nameof(Create)
+                       && m.IsGenericMethodDefinition
+                       && m.GetGenericArguments().Length == 1);
+
+      try
       {
-        JobType = jobType,
-        JobName = jobName,
-        JobDescription = jobDescription,
-        JobGroup = jobGroup,
-        TriggerName = triggerName,
-        TriggerDescription = triggerDescription,
-        CronExpression = config?.CronExpression ?? string.Empty,
-        IsActive = config?.IsActive ?? false,
-        RunOnce = config?.RunOnce ?? false,
-        RunAt = config?.RunAt ?? null,
-      };
-    }
-
-    public static class JobDiscovery
-    {
-      public static IEnumerable<Type> DiscoverJobs(Assembly assembly)
+        var generic = factoryMethod.MakeGenericMethod(jobType);
+        return (JobDescriptor)generic.Invoke(null, Array.Empty<object>())!;
+      }
+      catch (TargetInvocationException tie)
       {
-        return assembly
-            .GetTypes()
-            .Where(t =>
-                t is { IsClass: true, IsAbstract: false } &&
-                t.GetInterfaces().Any(i =>
-                    i.IsGenericType &&
-                    i.GetGenericTypeDefinition() == typeof(IJobMetadata<>)
-                )
-            );
+        throw tie.InnerException ?? tie;
       }
     }
+  }
 
-
-    public static class JobRegistry
+  public static class JobDiscovery
+  {
+    public static IEnumerable<Type> DiscoverJobs(Assembly assembly)
     {
-      public static List<JobDescriptor> BuildRegistry(
-          Assembly assembly,
-          IEnumerable<JobConfiguration> configs)
-      {
-        var jobs = JobDiscovery.DiscoverJobs(assembly);
-
-        var factoryMethod = typeof(JobDescriptorFactory)
-            .GetMethod(nameof(JobDescriptorFactory.Create))!;
-
-        return jobs
-          .Select(jobType =>
-          {
-            string className = jobType.Name;
-            var config = configs.FirstOrDefault(c => c.JobClass == className);
-
-            // Make Create<jobType>() dynamically
-            var generic = factoryMethod.MakeGenericMethod(jobType);
-            return (JobDescriptor)generic.Invoke(null, new object[] { config })!;
-          })
-          .ToList();
-      }
+      return assembly
+          .GetTypes()
+          .Where(t =>
+              t is { IsClass: true, IsAbstract: false } &&
+              t.GetInterfaces().Any(i =>
+                  i.IsGenericType &&
+                  i.GetGenericTypeDefinition() == typeof(IJobMetadata<>)
+              )
+          );
     }
+  }
 
 
+  public static class JobRegistry
+  {
+    public static List<JobDescriptor> BuildRegistry(Assembly assembly)
+    {
+      var jobs = JobDiscovery.DiscoverJobs(assembly);
+
+      return jobs
+        .Select(jobType => JobDescriptorFactory.Create(jobType))
+        .ToList();
+    }
+  }
+
+
+
+  /// <summary>
+  /// Represents a job scheduler that dynamically schedules or reschedules jobs based on database configurations.
+  /// </summary>
+  [DisallowConcurrentExecution]
+  public class DynamicJobScheduler : IJob
+  {
+    private readonly NpgSqlContext _dbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<DynamicJobScheduler> _logger;
+    private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
-    /// Represents a job scheduler that dynamically schedules or reschedules jobs based on database configurations.
+    /// Static job descriptor for the dynamic job scheduler.
     /// </summary>
-    [DisallowConcurrentExecution]
-    public class DynamicJobScheduler : IJob
+    private static readonly JobDescriptor s_jobDescriptor = new JobDescriptor
     {
-      private readonly NpgSqlContext _dbContext;
-      private readonly IConfiguration _configuration;
-      private readonly ILogger<DynamicJobScheduler> _logger;
-      private readonly IServiceProvider _serviceProvider;
+      JobName = "Dynamic Job Scheduler",
+      JobDescription = "Operates on an interval to determine if any new jobs need to be executed, scheduled, or rescheduled",
+      JobGroup = Constants.QuartzGroups.QUARTZ,
+      JobType = typeof(DynamicJobScheduler),
+      TriggerName = "Check job queue every minute",
+      TriggerDescription = "Operate every minute to determine if there are any new jobs to be scheduled or rescheduled",
+    };
 
-      /// <summary>
-      /// Static job descriptor for the dynamic job scheduler.
-      /// </summary>
-      private static readonly JobDescriptor s_jobDescriptor = new JobDescriptor
-      {
-        JobName = "Dynamic Job Scheduler",
-        JobDescription = "Operates on an interval to determine if any new jobs need to be executed, scheduled, or rescheduled",
-        JobGroup = Constants.QuartzGroups.QUARTZ,
-        JobType = typeof(DynamicJobScheduler),
-        TriggerName = "Check job queue every minute",
-        TriggerDescription = "Operate every minute to determine if there are any new jobs to be scheduled or rescheduled",
-        CronExpression = Utils.Configuration["EASEY_QUARTZ_SCHEDULER_DYNAMIC_JOB_SCHEDULER_SCHEDULE"] ?? "0 0/1 * * * ?",
-        IsActive = true,
-      };
+    private static readonly JobConfiguration s_jobConfiguration = new JobConfiguration
+    {
+      JobClass = nameof(DynamicJobScheduler),
+      CronExpression = Utils.Configuration["EASEY_QUARTZ_SCHEDULER_DYNAMIC_JOB_SCHEDULER_SCHEDULE"] ?? "0 0/1 * * * ?",
+      IsActive = true,
+    };
 
-      /// <summary>
-      /// Initializes a new instance of the <see cref="DynamicJobScheduler"/> class.
-      /// </summary>
-      /// <param name="dbContext">The database context.</param>
-      /// <param name="configuration">The application configuration.</param>
-      /// <param name="logger">The logger instance.</param>
-      public DynamicJobScheduler(NpgSqlContext dbContext, IConfiguration configuration, ILogger<DynamicJobScheduler> logger, IServiceProvider serviceProvider)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DynamicJobScheduler"/> class.
+    /// </summary>
+    /// <param name="dbContext">The database context.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <param name="logger">The logger instance.</param>
+    public DynamicJobScheduler(NpgSqlContext dbContext, IConfiguration configuration, ILogger<DynamicJobScheduler> logger, IServiceProvider serviceProvider)
+    {
+      _dbContext = dbContext;
+      _configuration = configuration;
+      _logger = logger;
+      _serviceProvider = serviceProvider;
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="JobKey"/> based on the provided job configuration.
+    /// </summary>
+    /// <param name="jobDescriptor">The job metadata and configuration.</param>
+    /// <returns>A <see cref="JobKey"/> object.</returns>
+    private static JobKey CreateJobKey(JobDescriptor jobDescriptor)
+    {
+      return new JobKey(jobDescriptor.JobName, jobDescriptor.JobGroup);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="TriggerBuilder"/> based on the provided job configuration.
+    /// </summary>
+    /// <param name="jobDescriptor">The job descriptor object.</param>
+    /// <param name="jobConfig">The job configuration.</param>
+    /// <returns>A <see cref="TriggerBuilder"/> object.</returns>
+    /// <exception cref="FormatException">Thrown if the cron expression is invalid.</exception>
+    private static TriggerBuilder CreateTriggerBuilder(JobDescriptor jobDescriptor, JobConfiguration jobConfig)
+    {
+      if (!CronExpression.IsValidExpression(jobConfig.CronExpression))
       {
-        _dbContext = dbContext;
-        _configuration = configuration;
-        _logger = logger;
-        _serviceProvider = serviceProvider;
+        throw new FormatException($"Invalid cron expression: {jobConfig.CronExpression}");
       }
+      return TriggerBuilder.Create()
+        .WithIdentity(CreateTriggerKey(jobDescriptor))
+        .WithDescription(jobDescriptor.TriggerDescription)
+        .WithSchedule(CronScheduleBuilder.CronSchedule(jobConfig.CronExpression).InTimeZone(Utils.getCurrentEasternZone()));
+    }
 
-      /// <summary>
-      /// Creates a new <see cref="JobKey"/> based on the provided job configuration.
-      /// </summary>
-      /// <param name="jobDescriptor">The job metadata and configuration.</param>
-      /// <returns>A <see cref="JobKey"/> object.</returns>
-      private static JobKey CreateJobKey(JobDescriptor jobDescriptor)
-      {
-        return new JobKey(jobDescriptor.JobName, jobDescriptor.JobGroup);
-      }
+    /// <summary>
+    /// Creates a new <see cref="TriggerKey"/> based on the provided job configuration.
+    /// </summary>
+    /// <param name="jobDescriptor">The job configuration and metadata.</param>
+    /// <returns>A <see cref="TriggerKey"/> object.</returns>
+    private static TriggerKey CreateTriggerKey(JobDescriptor jobDescriptor, bool once = false)
+    {
+      return new TriggerKey($"{jobDescriptor.TriggerName ?? jobDescriptor.JobName} ({(once ? "once" : "recurring")})", jobDescriptor.JobGroup);
+    }
 
-      /// <summary>
-      /// Creates a new <see cref="TriggerBuilder"/> based on the provided job configuration.
-      /// </summary>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      /// <returns>A <see cref="TriggerBuilder"/> object.</returns>
-      /// <exception cref="FormatException">Thrown if the cron expression is invalid.</exception>
-      private static TriggerBuilder CreateTriggerBuilder(JobDescriptor jobDescriptor)
+    /// <summary>
+    /// Retrieves the <see cref="Type"/> of the job specified in the job configuration.
+    /// </summary>
+    /// <param name="jobConfig">The job configuration.</param>
+    /// <returns>The <see cref="Type"/> of the job.</returns>
+    private static Type GetJobType(JobConfiguration jobConfig)
+    {
+      return Type.GetType($"Epa.Camd.Quartz.Scheduler.Jobs.{jobConfig.JobClass}");
+    }
+
+    /// <summary>
+    /// Executes the dynamic job scheduler logic to schedule or reschedule jobs.
+    /// </summary>
+    /// <param name="context">The job execution context.</param>
+    public async Task Execute(IJobExecutionContext context)
+    {
+      _logger.LogInformation("Starting Dynamic Job Scheduler");
+
+      try
       {
-        if (!CronExpression.IsValidExpression(jobDescriptor.CronExpression))
+        var jobConfigs = _dbContext.JobConfigurations.ToList();
+        _logger.LogInformation($"Found {jobConfigs.Count} job configurations");
+
+        var scheduler = context.Scheduler;
+
+        foreach (var jobConfig in jobConfigs)
         {
-          throw new FormatException($"Invalid cron expression: {jobDescriptor.CronExpression}");
-        }
-        return TriggerBuilder.Create()
-          .WithIdentity(CreateTriggerKey(jobDescriptor))
-          .WithDescription(jobDescriptor.TriggerDescription)
-          .WithSchedule(CronScheduleBuilder.CronSchedule(jobDescriptor.CronExpression).InTimeZone(Utils.getCurrentEasternZone()));
-      }
-
-      /// <summary>
-      /// Creates a new <see cref="TriggerKey"/> based on the provided job configuration.
-      /// </summary>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      /// <returns>A <see cref="TriggerKey"/> object.</returns>
-      private static TriggerKey CreateTriggerKey(JobDescriptor jobDescriptor, bool once = false)
-      {
-        return new TriggerKey($"{jobDescriptor.TriggerName ?? jobDescriptor.JobName} ({(once ? "once" : "recurring")})", jobDescriptor.JobGroup);
-      }
-
-      /// <summary>
-      /// Retrieves the <see cref="Type"/> of the job specified in the job configuration.
-      /// </summary>
-      /// <param name="jobConfig">The job configuration.</param>
-      /// <returns>The <see cref="Type"/> of the job.</returns>
-      private static Type GetJobType(JobConfiguration jobConfig)
-      {
-        return Type.GetType($"Epa.Camd.Quartz.Scheduler.Jobs.{jobConfig.JobClass}");
-      }
-
-      /// <summary>
-      /// Executes the dynamic job scheduler logic to schedule or reschedule jobs.
-      /// </summary>
-      /// <param name="context">The job execution context.</param>
-      public async Task Execute(IJobExecutionContext context)
-      {
-        _logger.LogInformation("Starting Dynamic Job Scheduler");
-
-        try
-        {
-          var jobConfigs = _dbContext.JobConfigurations.ToList();
-          _logger.LogInformation($"Found {jobConfigs.Count} job configurations");
-
-          var scheduler = context.Scheduler;
-
-          foreach (var jobConfig in jobConfigs)
+          JobDescriptor jobDescriptor = JobDescriptorFactory.Create(GetJobType(jobConfig));
+          if (jobDescriptor.JobType == null)
           {
-            JobDescriptor jobDescriptor = JobDescriptorFactory.Create(GetJobType(jobConfig), jobConfig);
-            if (jobDescriptor.JobType == null)
+            _logger.LogError($"Job type for class {jobConfig.JobClass} not found.");
+            continue;
+          }
+
+          if (jobConfig.IsActive)
+          {
+            try
             {
-              _logger.LogError($"Job type for class {jobConfig.JobClass} not found.");
-              continue;
-            }
+              // Schedule the job according to its configured cron expression.
+              await ScheduleJob(scheduler, jobDescriptor, jobConfig);
 
-            if (jobConfig.IsActive)
-            {
-              try
+              if (jobConfig.RunOnce == true)
               {
-                // Schedule the job according to its configured cron expression.
-                await ScheduleJob(scheduler, jobDescriptor);
+                var runAt = jobConfig.RunAt;
 
-                if (jobConfig.RunOnce == true)
-                {
-                  var runAt = jobConfig.RunAt;
+                // Toggle the `RunOnce` flag to prevent the job from running again.
+                jobConfig.RunOnce = false;
+                jobConfig.RunAt = null;
+                _dbContext.JobConfigurations.Update(jobConfig);
+                _dbContext.SaveChanges();
 
-                  // Toggle the `RunOnce` flag to prevent the job from running again.
-                  jobConfig.RunOnce = false;
-                  jobConfig.RunAt = null;
-                  _dbContext.JobConfigurations.Update(jobConfig);
-                  _dbContext.SaveChanges();
-
-                  // Schedule the job to run once at a specified time.
-                  await ScheduleJobOnce(scheduler, jobDescriptor, runAt);
-                }
-              }
-              catch (Exception e)
-              {
-                _logger.LogError($"Error scheduling job {jobDescriptor.JobName}: {e.Message}");
+                // Schedule the job to run once at a specified time.
+                await ScheduleJobOnce(scheduler, jobDescriptor, runAt);
               }
             }
-            else
+            catch (Exception e)
             {
-              try
-              {
-                await UnscheduleJob(scheduler, jobDescriptor, _logger);
-              }
-              catch (Exception e)
-              {
-                _logger.LogError($"Error unscheduling job {jobDescriptor.JobName}: {e.Message}");
-              }
+              _logger.LogError($"Error scheduling job {jobDescriptor.JobName}: {e.Message}");
+            }
+          }
+          else
+          {
+            try
+            {
+              await UnscheduleJob(scheduler, jobDescriptor, _logger);
+            }
+            catch (Exception e)
+            {
+              _logger.LogError($"Error unscheduling job {jobDescriptor.JobName}: {e.Message}");
             }
           }
         }
-        catch (Exception e)
-        {
-          _logger.LogError($"Error in Dynamic Job Scheduler: {e.Message}");
-        }
-
-        _logger.LogInformation("Completed Dynamic Job Scheduler");
+      }
+      catch (Exception e)
+      {
+        _logger.LogError($"Error in Dynamic Job Scheduler: {e.Message}");
       }
 
-      /// <summary>
-      /// Registers a job with the specified services based on the job configuration.
-      /// </summary>
-      /// <param name="services">The service collection.</param>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      private static void RegisterJob(IServiceCollection services, JobDescriptor jobDescriptor)
+      _logger.LogInformation("Completed Dynamic Job Scheduler");
+    }
+
+    /// <summary>
+    /// Registers a job with the specified services based on the job configuration.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="jobDescriptor">The job configuration and metadata.</param>
+    private static void RegisterJob(IServiceCollection services, JobDescriptor jobDescriptor)
+    {
+      ILogger<DynamicJobScheduler> staticLogger = LoggerProvider.GetLogger<DynamicJobScheduler>();
+      var jobType = jobDescriptor.JobType;
+      if (jobType != null)
       {
-        ILogger<DynamicJobScheduler> staticLogger = LoggerProvider.GetLogger<DynamicJobScheduler>();
+        services.AddQuartzJob(jobType, CreateJobKey(jobDescriptor), jobDescriptor.JobDescription);
+        staticLogger.LogInformation("Registered job: {JobType} with Quartz", jobDescriptor.JobType);
+      }
+    }
+
+    /// <summary>
+    /// Registers all jobs with Quartz based on database configurations.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="jobDescriptors">A list of job descriptors to register.</param>
+    public static void RegisterWithQuartz(IServiceCollection services, List<JobDescriptor> jobDescriptors)
+    {
+      RegisterJob(services, s_jobDescriptor);
+
+      foreach (var jobDescriptor in jobDescriptors)
+      {
+        RegisterJob(services, jobDescriptor);
+      }
+    }
+
+    /// <summary>
+    /// Schedules a job using the provided scheduler, application builder, and logger.
+    /// </summary>
+    /// <param name="scheduler">The scheduler instance.</param>
+    /// <param name="app">The application builder.</param>
+    /// <param name="jobDescriptor">The job descriptor object.</param>
+    /// <param name="jobConfig">The job configuration.</param>
+    /// <param name="logger">The logger instance.</param>
+    private static async Task ScheduleJob(IScheduler scheduler,
+                                          IApplicationBuilder app,
+                                          JobDescriptor jobDescriptor,
+                                          JobConfiguration jobConfig,
+                                          ILogger logger)
+    {
+      await ScheduleJobInternal(scheduler, jobDescriptor, jobConfig, logger, (triggerBuilder) =>
+      {
+        return Task.Run(() => app.UseQuartzJob(jobDescriptor.JobType, triggerBuilder));
+      });
+    }
+
+    /// <summary>
+    /// Schedules a job using the provided scheduler, service provider, and job configuration.
+    /// </summary>
+    /// <param name="scheduler">The scheduler instance.</param>
+    /// <param name="jobDescriptor">The job descriptor object.</param>
+    /// <param name="jobConfig">The job configuration.</param>
+    private async Task ScheduleJob(IScheduler scheduler, JobDescriptor jobDescriptor, JobConfiguration jobConfig)
+    {
+      await ScheduleJobInternal(scheduler, jobDescriptor, jobConfig, _logger, async (triggerBuilder) =>
+      {
+        var scheduleJobs = _serviceProvider.GetService<IEnumerable<IScheduleJob>>();
+        await IJobRegistratorExtensions.UseQuartzJob(scheduleJobs, scheduler, jobDescriptor.JobType, triggerBuilder);
+      });
+    }
+
+    /// <summary>
+    /// Internal method to schedule a job using the specified scheduler, job configuration, logger, and schedule action.
+    /// </summary>
+    /// <param name="scheduler">The scheduler instance.</param>
+    /// <param name="jobDescriptor">The job descriptor object.</param>
+    /// <param name="jobConfig">The job configuration.</param>
+    /// <param name="logger">The logger instance.</param>
+    /// <param name="scheduleAction">The action to schedule the job.</param>
+    private static async Task ScheduleJobInternal(IScheduler scheduler,
+                                                  JobDescriptor jobDescriptor,
+                                                  JobConfiguration jobConfig,
+                                                  ILogger logger,
+                                                  Func<TriggerBuilder, Task> scheduleAction)
+    {
+      if (string.IsNullOrEmpty(jobConfig.CronExpression))
+      {
+        // Unschedule the job if the cron expression is empty.
+        await UnscheduleJob(scheduler, jobDescriptor, logger);
+        return;
+      }
+
+      JobKey jobKey = CreateJobKey(jobDescriptor);
+      TriggerKey triggerKey = CreateTriggerKey(jobDescriptor);
+      TriggerBuilder triggerBuilder = CreateTriggerBuilder(jobDescriptor, jobConfig);
+
+      if (await scheduler.CheckExists(jobKey))
+      {
+        if (await scheduler.CheckExists(triggerKey))
+        {
+          // Reschedule if the job's cron expression has changed.
+          ITrigger trigger = await scheduler.GetTrigger(triggerKey);
+          if (
+            trigger is ICronTrigger cronTrigger &&
+            cronTrigger.CronExpressionString != jobConfig.CronExpression
+          )
+          {
+            await scheduler.RescheduleJob(triggerKey, triggerBuilder.Build());
+            logger.LogInformation($"Rescheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
+          }
+        }
+        else
+        {
+          // Schedule the job with the new trigger.
+          await scheduler.ScheduleJob(triggerBuilder.ForJob(jobKey).Build());
+          logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
+        }
+      }
+      else
+      {
+        // Create a new job detail and schedule the job.
+        await scheduleAction(triggerBuilder);
+        logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobConfig.CronExpression}]");
+      }
+    }
+
+    /// <summary>
+    /// Schedules a job to run once, immediately or at a specified time.
+    /// </summary>
+    /// <param name="scheduler">The scheduler instance.</param>
+    /// <param name="jobDescriptor">The job descriptor object.</param>
+    /// <param name="runAt">The time to run the job, or null to run immediately.</param>
+    private async Task ScheduleJobOnce(IScheduler scheduler, JobDescriptor jobDescriptor, DateTime? runAt = null)
+    {
+      JobKey jobKey = CreateJobKey(jobDescriptor);
+      TriggerKey triggerKey = CreateTriggerKey(jobDescriptor, once: true);
+
+      // Retrieve the job detail using the JobKey.
+      IJobDetail jobDetail = await scheduler.GetJobDetail(jobKey);
+      if (jobDetail == null)
+      {
+        _logger.LogInformation($"Job with key {jobKey.Name} not found. Adding job to the scheduler.");
+
+        // Create a new job detail.
         var jobType = jobDescriptor.JobType;
-        if (jobType != null)
+        if (jobType == null)
         {
-          services.AddQuartzJob(jobType, CreateJobKey(jobDescriptor), jobDescriptor.JobDescription);
-          staticLogger.LogInformation("Registered job: {JobType} with Quartz", jobDescriptor.JobType);
-        }
-      }
-
-      /// <summary>
-      /// Registers all jobs with Quartz based on database configurations.
-      /// </summary>
-      /// <param name="services">The service collection.</param>
-      /// <param name="jobDescriptors">A list of job descriptors to register.</param>
-      public static void RegisterWithQuartz(IServiceCollection services, List<JobDescriptor> jobDescriptors)
-      {
-        RegisterJob(services, s_jobDescriptor);
-
-        foreach (var jobDescriptor in jobDescriptors)
-        {
-          RegisterJob(services, jobDescriptor);
-        }
-      }
-
-      /// <summary>
-      /// Schedules a job using the provided scheduler, application builder, and logger.
-      /// </summary>
-      /// <param name="scheduler">The scheduler instance.</param>
-      /// <param name="app">The application builder.</param>
-      /// <param name="logger">The logger instance.</param>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      private static async Task ScheduleJob(IScheduler scheduler, IApplicationBuilder app, JobDescriptor jobDescriptor, ILogger logger)
-      {
-        await ScheduleJobInternal(scheduler, jobDescriptor, logger, (triggerBuilder) =>
-        {
-          return Task.Run(() => app.UseQuartzJob(jobDescriptor.JobType, triggerBuilder));
-        });
-      }
-
-      /// <summary>
-      /// Schedules a job using the provided scheduler, service provider, and job configuration.
-      /// </summary>
-      /// <param name="scheduler">The scheduler instance.</param>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      private async Task ScheduleJob(IScheduler scheduler, JobDescriptor jobDescriptor)
-      {
-        await ScheduleJobInternal(scheduler, jobDescriptor, _logger, async (triggerBuilder) =>
-        {
-          var scheduleJobs = _serviceProvider.GetService<IEnumerable<IScheduleJob>>();
-          await IJobRegistratorExtensions.UseQuartzJob(scheduleJobs, scheduler, jobDescriptor.JobType, triggerBuilder);
-        });
-      }
-
-      /// <summary>
-      /// Internal method to schedule a job using the specified scheduler, job configuration, logger, and schedule action.
-      /// </summary>
-      /// <param name="scheduler">The scheduler instance.</param>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      /// <param name="logger">The logger instance.</param>
-      /// <param name="scheduleAction">The action to schedule the job.</param>
-      private static async Task ScheduleJobInternal(IScheduler scheduler, JobDescriptor jobDescriptor, ILogger logger, Func<TriggerBuilder, Task> scheduleAction)
-      {
-        if (string.IsNullOrEmpty(jobDescriptor.CronExpression))
-        {
-          // Unschedule the job if the cron expression is empty.
-          await UnscheduleJob(scheduler, jobDescriptor, logger);
+          _logger.LogError($"Job type {jobDescriptor.JobType} not found.");
           return;
         }
 
-        JobKey jobKey = CreateJobKey(jobDescriptor);
-        TriggerKey triggerKey = CreateTriggerKey(jobDescriptor);
-        TriggerBuilder triggerBuilder = CreateTriggerBuilder(jobDescriptor);
+        jobDetail = JobBuilder
+          .Create(jobType)
+          .WithIdentity(jobKey)
+          .WithDescription(jobDescriptor.JobDescription)
+          .StoreDurably(true) // Ensure job persists even without a trigger
+          .Build();
 
-        if (await scheduler.CheckExists(jobKey))
+        await scheduler.AddJob(jobDetail, replace: false); // Only add the job if it doesn't exist
+      }
+
+      // Create the trigger to run once, immediately or at a specified time.
+      TriggerBuilder triggerBuilder = TriggerBuilder.Create()
+          .WithIdentity(triggerKey)
+          .WithDescription($"Run once trigger for job {jobKey.Name}");
+
+      if (runAt.HasValue)
+      {
+        // Ensure `runAt` is in Eastern Time.
+        TimeZoneInfo easternZone = Utils.getCurrentEasternZone();
+        DateTimeOffset easternTime = new DateTimeOffset(runAt.Value, easternZone.GetUtcOffset(runAt.Value));
+        triggerBuilder.StartAt(easternTime);
+        _logger.LogInformation($"Scheduling job {jobKey.Name} to run once at {easternTime}");
+      }
+      else
+      {
+        triggerBuilder.StartNow();
+        _logger.LogInformation($"Scheduling job {jobKey.Name} to run immediately");
+      }
+
+      var newTrigger = triggerBuilder.ForJob(jobKey).Build();
+
+      if (await scheduler.CheckExists(triggerKey))
+      {
+        await scheduler.RescheduleJob(triggerKey, newTrigger);
+      }
+      else
+      {
+        await scheduler.ScheduleJob(newTrigger);
+      }
+    }
+
+    public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app, ILogger logger)
+    {
+      await ScheduleJob(scheduler, app, s_jobDescriptor, s_jobConfiguration, logger);
+    }
+
+    /// <summary>
+    /// Unschedules a job from the scheduler based on the job configuration.
+    /// </summary>
+    /// <param name="scheduler">The scheduler instance.</param>
+    /// <param name="jobDescriptor">The job descriptor object.</param>
+    private static async Task UnscheduleJob(IScheduler scheduler, JobDescriptor jobDescriptor, ILogger logger)
+    {
+      TriggerKey triggerKey = CreateTriggerKey(jobDescriptor);
+
+      if (await scheduler.CheckExists(triggerKey))
+      {
+        bool unscheduled = await scheduler.UnscheduleJob(triggerKey);
+        if (unscheduled)
         {
-          if (await scheduler.CheckExists(triggerKey))
-          {
-            // Reschedule if the job's cron expression has changed.
-            ITrigger trigger = await scheduler.GetTrigger(triggerKey);
-            if (
-              trigger is ICronTrigger cronTrigger &&
-              cronTrigger.CronExpressionString != jobDescriptor.CronExpression
-            )
-            {
-              await scheduler.RescheduleJob(triggerKey, triggerBuilder.Build());
-              logger.LogInformation($"Rescheduled {jobKey.Name} with cron expression [{jobDescriptor.CronExpression}]");
-            }
-          }
-          else
-          {
-            // Schedule the job with the new trigger.
-            await scheduler.ScheduleJob(triggerBuilder.ForJob(jobKey).Build());
-            logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobDescriptor.CronExpression}]");
-          }
+          logger.LogInformation($"Successfully removed trigger for job: {jobDescriptor.JobName}");
         }
         else
         {
-          // Create a new job detail and schedule the job.
-          await scheduleAction(triggerBuilder);
-          logger.LogInformation($"Scheduled {jobKey.Name} with cron expression [{jobDescriptor.CronExpression}]");
-        }
-      }
-
-      /// <summary>
-      /// Schedules a job to run once, immediately or at a specified time.
-      /// </summary>
-      /// <param name="scheduler">The scheduler instance.</param>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      /// <param name="runAt">The time to run the job, or null to run immediately.</param>
-      private async Task ScheduleJobOnce(IScheduler scheduler, JobDescriptor jobDescriptor, DateTime? runAt = null)
-      {
-        JobKey jobKey = CreateJobKey(jobDescriptor);
-        TriggerKey triggerKey = CreateTriggerKey(jobDescriptor, once: true);
-
-        // Retrieve the job detail using the JobKey.
-        IJobDetail jobDetail = await scheduler.GetJobDetail(jobKey);
-        if (jobDetail == null)
-        {
-          _logger.LogInformation($"Job with key {jobKey.Name} not found. Adding job to the scheduler.");
-
-          // Create a new job detail.
-          var jobType = jobDescriptor.JobType;
-          if (jobType == null)
-          {
-            _logger.LogError($"Job type {jobDescriptor.JobType} not found.");
-            return;
-          }
-
-          jobDetail = JobBuilder
-            .Create(jobType)
-            .WithIdentity(jobKey)
-            .WithDescription(jobDescriptor.JobDescription)
-            .StoreDurably(true) // Ensure job persists even without a trigger
-            .Build();
-
-          await scheduler.AddJob(jobDetail, replace: false); // Only add the job if it doesn't exist
-        }
-
-        // Create the trigger to run once, immediately or at a specified time.
-        TriggerBuilder triggerBuilder = TriggerBuilder.Create()
-            .WithIdentity(triggerKey)
-            .WithDescription($"Run once trigger for job {jobKey.Name}");
-
-        if (runAt.HasValue)
-        {
-          // Ensure `runAt` is in Eastern Time.
-          TimeZoneInfo easternZone = Utils.getCurrentEasternZone();
-          DateTimeOffset easternTime = new DateTimeOffset(runAt.Value, easternZone.GetUtcOffset(runAt.Value));
-          triggerBuilder.StartAt(easternTime);
-          _logger.LogInformation($"Scheduling job {jobKey.Name} to run once at {easternTime}");
-        }
-        else
-        {
-          triggerBuilder.StartNow();
-          _logger.LogInformation($"Scheduling job {jobKey.Name} to run immediately");
-        }
-
-        var newTrigger = triggerBuilder.ForJob(jobKey).Build();
-
-        if (await scheduler.CheckExists(triggerKey))
-        {
-          await scheduler.RescheduleJob(triggerKey, newTrigger);
-        }
-        else
-        {
-          await scheduler.ScheduleJob(newTrigger);
-        }
-      }
-
-      public static async Task ScheduleWithQuartz(IScheduler scheduler, IApplicationBuilder app, ILogger logger)
-      {
-        await ScheduleJob(scheduler, app, s_jobDescriptor, logger);
-      }
-
-      /// <summary>
-      /// Unschedules a job from the scheduler based on the job configuration.
-      /// </summary>
-      /// <param name="scheduler">The scheduler instance.</param>
-      /// <param name="jobDescriptor">The job configuration and metadata.</param>
-      private static async Task UnscheduleJob(IScheduler scheduler, JobDescriptor jobDescriptor, ILogger logger)
-      {
-        TriggerKey triggerKey = CreateTriggerKey(jobDescriptor);
-
-        if (await scheduler.CheckExists(triggerKey))
-        {
-          bool unscheduled = await scheduler.UnscheduleJob(triggerKey);
-          if (unscheduled)
-          {
-            logger.LogInformation($"Successfully removed trigger for job: {jobDescriptor.JobName}");
-          }
-          else
-          {
-            logger.LogWarning($"Failed to remove trigger for job: {jobDescriptor.JobName}.");
-          }
+          logger.LogWarning($"Failed to remove trigger for job: {jobDescriptor.JobName}.");
         }
       }
     }

--- a/admin/Jobs/EmailQueue.cs
+++ b/admin/Jobs/EmailQueue.cs
@@ -16,8 +16,14 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class EmailQueue : IJob
+  public class EmailQueue : IJob, IJobMetadata<EmailQueue>
   {
+    public static string JobName => "Email Queue";
+    public static string JobDescription => "Operates on an interval to determine if emails in the send email table can be sent.";
+    public static string JobGroup => Constants.QuartzGroups.MAINTAINANCE;
+    public static string TriggerName => "Email Queue Trigger";
+    public static string TriggerDescription => "Operate every minute to determine if there are emails in the queue which can be sent";
+
     private NpgSqlContext _dbContext = null;
     private readonly ILogger<EmailQueue> _logger;
     private readonly Guid _jobId = Guid.NewGuid();

--- a/admin/Jobs/EvaluationJobQueue.cs
+++ b/admin/Jobs/EvaluationJobQueue.cs
@@ -12,8 +12,14 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class EvaluationJobQueue : IJob
+  public class EvaluationJobQueue : IJob, IJobMetadata<EvaluationJobQueue>
   {
+    public static string JobName => "Evaluation Job Queue";
+    public static string JobDescription => "Operates on an interval to determine if files in evaluation queue can be triggered.";
+    public static string JobGroup => Constants.QuartzGroups.MAINTAINANCE;
+    public static string TriggerName => "Evaluation Job Queue Trigger";
+    public static string TriggerDescription => "Operate every 15 seconds to determine if there are files in evaluation queue which can be triggered";
+
     private NpgSqlContext _dbContext = null;
     private readonly ILogger<EvaluationJobQueue> _logger;
     private IConfiguration Configuration { get; }

--- a/admin/Jobs/InventoryChanges.cs
+++ b/admin/Jobs/InventoryChanges.cs
@@ -17,8 +17,14 @@ using Epa.Camd.Quartz.Scheduler.Models;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class InventoryChanges : IJob
+  public class InventoryChanges : IJob, IJobMetadata<InventoryChanges>
   {
+    public static string JobName => "Inventory Changes";
+    public static string JobDescription => "Operates on an interval to determine if any remote facility/unit inventory changes require changes to existing monitoring plans.";
+    public static string JobGroup => Constants.QuartzGroups.MAINTAINANCE;
+    public static string TriggerName => "Inventory Changes Trigger";
+    public static string TriggerDescription => "Operate every 5 minutes to determine if there are any new changes recorded in the inventory status log.";
+
     private Guid job_id = Guid.NewGuid();
 
     private NpgSqlContext _dbContext = null;

--- a/admin/Jobs/PdemJob.cs
+++ b/admin/Jobs/PdemJob.cs
@@ -15,13 +15,17 @@ using DatabaseAccess;
 using ECMPS.DM;
 using ECMPS.Checks.EmissionsReport;
 
-
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
 
     [DisallowConcurrentExecution]
-    public class PdemJob : IJob
+    public class PdemJob : IJob, IJobMetadata<PdemJob>
     {
+        public static string JobName => "Program Data Emissions Job Queue";
+        public static string JobDescription => "Operates on an interval to determine if emission reports in PDEM_REPORT table need to be generated.";
+        public static string JobGroup => Constants.QuartzGroups.MAINTAINANCE;
+        public static string TriggerName => "Program Data Emissions Job Queue Trigger";
+        public static string TriggerDescription => "Operate every minute to determine if there are PDEM reports which can be triggered for generation";
 
         public PdemJob(NpgSqlContext dbContext, IConfiguration configuration, ILogger<cUpdateEmissionsDb> logger)
         {

--- a/admin/Jobs/SubmissionJobQueue.cs
+++ b/admin/Jobs/SubmissionJobQueue.cs
@@ -15,8 +15,14 @@ using Microsoft.Extensions.Logging;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
   [DisallowConcurrentExecution]
-  public class SubmissionJobQueue : IJob
+  public class SubmissionJobQueue : IJob, IJobMetadata<SubmissionJobQueue>
   {
+    public static string JobName => "Submission Job Queue";
+    public static string JobDescription => "Operates on an interval to determine if sets in SubmissionSet table can be submitted.";
+    public static string JobGroup => Constants.QuartzGroups.MAINTAINANCE;
+    public static string TriggerName => "Submission Job Queue Trigger";
+    public static string TriggerDescription => "Operate every minute to determine if there are files in submission queue which can be triggered";
+
     private NpgSqlContext _dbContext = null;
     private readonly ILogger<SubmissionJobQueue> _logger;
     private IConfiguration Configuration { get; }

--- a/admin/Jobs/SubmissionWindowManagement.cs
+++ b/admin/Jobs/SubmissionWindowManagement.cs
@@ -14,8 +14,14 @@ using Epa.Camd.Quartz.Scheduler.Models;
 namespace Epa.Camd.Quartz.Scheduler.Jobs
 {
     [DisallowConcurrentExecution]
-    public class SubmissionWindowManagement : IJob
+    public class SubmissionWindowManagement : IJob, IJobMetadata<SubmissionWindowManagement>
     {
+        public static string JobName => "Submission Window Management";
+        public static string JobDescription => "Manages emission submission windows";
+        public static string JobGroup => Constants.QuartzGroups.MAINTAINANCE;
+        public static string TriggerName => "Submission Window Management Trigger";
+        public static string TriggerDescription => "Runs daily at 3AM to initialize and close emission submission access";
+
         private readonly NpgSqlContext _dbContext;
         private readonly IConfiguration _configuration;
         private readonly ILogger<SubmissionWindowManagement> _logger;

--- a/admin/Models/JobConfiguration.cs
+++ b/admin/Models/JobConfiguration.cs
@@ -8,23 +8,23 @@ namespace Epa.Camd.Quartz.Scheduler.Models
   public class JobConfiguration
   {
     [Key]
-    [Column("job_type")]
-    public string JobType { get; set; }
+    [Column("job_class")]
+    public string JobClass { get; set; }
 
-    [Column("job_name")]
-    public string JobName { get; set; }
+    //[Column("job_name")]
+    //public string JobName { get; set; }
 
-    [Column("job_description")]
-    public string JobDescription { get; set; }
+    //[Column("job_description")]
+    //public string JobDescription { get; set; }
 
-    [Column("job_group")]
-    public string JobGroup { get; set; }
+    //[Column("job_group")]
+    //public string JobGroup { get; set; }
 
-    [Column("trigger_name")]
-    public string TriggerName { get; set; }
+    //[Column("trigger_name")]
+    //public string TriggerName { get; set; }
 
-    [Column("trigger_description")]
-    public string TriggerDescription { get; set; }
+    //[Column("trigger_description")]
+    //public string TriggerDescription { get; set; }
 
     [Column("cron_expression")]
     public string CronExpression { get; set; }

--- a/admin/Models/JobConfiguration.cs
+++ b/admin/Models/JobConfiguration.cs
@@ -11,21 +11,6 @@ namespace Epa.Camd.Quartz.Scheduler.Models
     [Column("job_class")]
     public string JobClass { get; set; }
 
-    //[Column("job_name")]
-    //public string JobName { get; set; }
-
-    //[Column("job_description")]
-    //public string JobDescription { get; set; }
-
-    //[Column("job_group")]
-    //public string JobGroup { get; set; }
-
-    //[Column("trigger_name")]
-    //public string TriggerName { get; set; }
-
-    //[Column("trigger_description")]
-    //public string TriggerDescription { get; set; }
-
     [Column("cron_expression")]
     public string CronExpression { get; set; }
 

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -132,7 +132,9 @@ namespace Epa.Camd.Quartz.Scheduler
       BulkDataFile.RegisterWithQuartz(services);
       ProcessSubmissionReminders.RegisterWithQuartz(services);
       ProcessWindowNotifications.RegisterWithQuartz(services);
-      DynamicJobScheduler.RegisterWithQuartz(services, jobConfigurations);
+
+      List<JobDescriptor> jobDescriptors = JobRegistry.BuildRegistry(typeof(DynamicJobScheduler).Assembly, jobConfigurations);
+      DynamicJobScheduler.RegisterWithQuartz(services, jobDescriptors);
 
       services.AddTransient<CheckEngineEvaluationListener>(); //DI for CheckEngineListener
       CheckEngineEvaluationListener.ServiceCollection = services; // Set service collection of the listener

--- a/admin/Startup.cs
+++ b/admin/Startup.cs
@@ -54,12 +54,10 @@ namespace Epa.Camd.Quartz.Scheduler
       // >
       // We want to access the `NpgSqlContext` here to retrieve the CORS options and job configurations from the database.
       List<CorsOptions> corsOptions;
-      List<JobConfiguration> jobConfigurations;
       using (var scope = services.BuildServiceProvider().CreateScope()) // Build a scoped service provider to access the DbContext
       {
         NpgSqlContext dbContext = scope.ServiceProvider.GetRequiredService<NpgSqlContext>();
         corsOptions = dbContext.CorsOptions.ToList();
-        jobConfigurations = dbContext.JobConfigurations.ToList();
       }
 #pragma warning restore ASP0000
 
@@ -133,7 +131,7 @@ namespace Epa.Camd.Quartz.Scheduler
       ProcessSubmissionReminders.RegisterWithQuartz(services);
       ProcessWindowNotifications.RegisterWithQuartz(services);
 
-      List<JobDescriptor> jobDescriptors = JobRegistry.BuildRegistry(typeof(DynamicJobScheduler).Assembly, jobConfigurations);
+      List<JobDescriptor> jobDescriptors = JobRegistry.BuildRegistry(typeof(DynamicJobScheduler).Assembly);
       DynamicJobScheduler.RegisterWithQuartz(services, jobDescriptors);
 
       services.AddTransient<CheckEngineEvaluationListener>(); //DI for CheckEngineListener


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6882

## Main Changes:

- Moved several fields from the CAMDAUX.JOB_CONFIGURATION table into the Quartz jobs as static properties.
- Added an `IJobMetadata` interface that dynamically scheduled jobs must implement.
- Switched to registering all jobs that implement the `IJobMetadata` interface at startup, rather than just those declared in CAMDAUX.JOB_CONFIGURATION. However, jobs are only _scheduled_ if they have corresponding rows in the configuration table.