### PR TITLE
#6689 Enable LINEAR-2-D

### DIFF
--- a/CheckEngine/QA/Checks/LinearityChecks.cs
+++ b/CheckEngine/QA/Checks/LinearityChecks.cs
@@ -197,8 +197,6 @@ namespace ECMPS.Checks.LinearityChecks
 						}
 					}
 					
-					/* TODO: BeginDateHour / etc is not defined as part of qaParams.CurrentLinearityTest
-					
 					if ((qaParams.LinearityComponentValid == true) && TestTypeCd.InList("LINE,HGLINE,HGSI3"))
                     {
 						int count = qaParams.SystemComponentRecords.CountRows
@@ -206,10 +204,10 @@ namespace ECMPS.Checks.LinearityChecks
 								new cFilterCondition[]
                                 {
 									new cFilterCondition("COMPONENT_ID", qaParams.CurrentLinearityTest.ComponentId),
-									new cFilterCondition("BEGIN_DATEHOUR", eFilterConditionRelativeCompare.LessThanOrEqual.ToString(), qaParams.CurrentLinearityTest.BeginDatehour.Default(DateTypes.START), eNullDateDefault.Min),
-									new cFilterCondition("END_DATEHOUR", eFilterConditionRelativeCompare.GreaterThanOrEqual.ToString(), qaParams.CurrentLinearityTest.BeginDatehour.Default(DateTypes.START), eNullDateDefault.Max),
-									new cFilterCondition("BEGIN_DATEHOUR", eFilterConditionRelativeCompare.LessThanOrEqual.ToString(), qaParams.CurrentLinearityTest.EndDatehour.Default(DateTypes.END), eNullDateDefault.Min),
-									new cFilterCondition("END_DATEHOUR", eFilterConditionRelativeCompare.GreaterThanOrEqual.ToString(), qaParams.CurrentLinearityTest.EndDatehour.Default(DateTypes.END), eNullDateDefault.Max)
+									new cFilterCondition("BEGIN_DATEHOUR", eFilterConditionRelativeCompare.LessThanOrEqual, qaParams.CurrentLinearityTest.BeginDatehour.Default(DateTypes.START), eNullDateDefault.Min),
+									new cFilterCondition("END_DATEHOUR", eFilterConditionRelativeCompare.GreaterThanOrEqual, qaParams.CurrentLinearityTest.BeginDatehour.Default(DateTypes.START), eNullDateDefault.Max),
+									new cFilterCondition("BEGIN_DATEHOUR", eFilterConditionRelativeCompare.LessThanOrEqual, qaParams.CurrentLinearityTest.EndDatehour.Default(DateTypes.END), eNullDateDefault.Min),
+									new cFilterCondition("END_DATEHOUR", eFilterConditionRelativeCompare.GreaterThanOrEqual, qaParams.CurrentLinearityTest.EndDatehour.Default(DateTypes.END), eNullDateDefault.Max)
 								}
 							);
 
@@ -226,7 +224,6 @@ namespace ECMPS.Checks.LinearityChecks
 							}
 						}
                     }
-					*/
 				}
 			}
 			catch (Exception ex)


### PR DESCRIPTION
Uncommented the code that produces LINEAR-2-D which had been updated for ECMPS 2.0 but was likely commented out because the update added ToString() to the eFilterConditionRelativeCompare values.  That change meant that the set of arguments for the cFilterCondition constructer did not actually match the signature for a constructer, and therefore a compile error occurred.
