### PR TITLE
Include 'HG' in component type check for SPAN-2-B result

### DIFF
--- a/CheckEngine/MonitorPlan/Checks/SpanChecks.cs
+++ b/CheckEngine/MonitorPlan/Checks/SpanChecks.cs
@@ -291,7 +291,7 @@ namespace ECMPS.Checks.SpanChecks
               Category.SetCheckParameter("Span_MEC_Value_Valid", false, eParameterDataType.Boolean);
               Category.CheckCatalogResult = "A";
             }
-            else if( ComponentTypeCd.InList( "SO2,NOX" ) && ( SpanScaleCd == "H" ) &&
+            else if( ComponentTypeCd.InList( "SO2,NOX,HG" ) && ( SpanScaleCd == "H" ) &&
                      (CurrentSpan["Default_High_Range"] != DBNull.Value))
             {
               Category.SetCheckParameter("Span_MEC_Value_Valid", false, eParameterDataType.Boolean);


### PR DESCRIPTION
## Ticket
[Check Gaps: MP Screen Only and Import Checks](https://github.com/US-EPA-CAMD/easey-ui/issues/6907)

## Change

- Include 'HG' in component type check for `SPAN-2-B `