### PR TITLE
Fix/6925 duplicate check engine evaluation jobs

### DIFF
--- a/admin/Jobs/CheckEngineEvaluation.cs
+++ b/admin/Jobs/CheckEngineEvaluation.cs
@@ -280,7 +280,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                         SELECT eq.*
                         FROM camdecmpsaux.evaluation_queue eq
                         JOIN camdecmpsaux.evaluation_set es USING(evaluation_set_id)
-                        WHERE eq.process_cd = 'EM' AND eq.status_cd IN ('PENDING', 'QUEUED', 'WIP') AND es.mon_plan_id = {0}
+                        WHERE eq.process_cd = 'EM' AND eq.status_cd IN ('PENDING', 'QUEUED', 'CLAIMED', 'WIP') AND es.mon_plan_id = {0}
                         ORDER BY eq.rpt_period_id
                         ", es.MonPlanId).ToList();
 

--- a/admin/Jobs/EvaluationJobQueue.cs
+++ b/admin/Jobs/EvaluationJobQueue.cs
@@ -49,29 +49,29 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                 // Exit if nothing in queue
                 if (inQueue.Count == 0) continue;
 
-                List<Evaluation> wip = _dbContext.Evaluations.FromSqlRaw(@"
+                List<Evaluation> wipOrClaimed = _dbContext.Evaluations.FromSqlRaw(@"
                     SELECT *
                     FROM camdecmpsaux.evaluation_queue
                     WHERE process_cd = {0} AND status_cd in ('WIP', 'CLAIMED')
                     ORDER BY queued_time", processType
                 ).ToList();
 
-                _logger.LogInformation("Found {Count} {Type} evaluations in WIP status", 
-                    wip.Count, processType);
+                _logger.LogInformation("Found {Count} {Type} evaluations in WIP or CLAIMED status", 
+                    wipOrClaimed.Count, processType);
 
                 int maxAllowed = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_" + processType +"_EVALUATIONS"]);
                 _logger.LogInformation("Max allowed {Type} evaluations: {MaxAllowed}", 
                     processType, maxAllowed);
 
                 // Exit if at max
-                if(wip.Count >= maxAllowed)
+                if(wipOrClaimed.Count >= maxAllowed)
                 {
                   _logger.LogInformation("Maximum number of {Type} evaluations ({MaxAllowed}) already in progress", 
                       processType, maxAllowed);
                   continue;
                 }
 
-                int jobs_to_schedule = maxAllowed - wip.Count;
+                int jobs_to_schedule = maxAllowed - wipOrClaimed.Count;
                 _logger.LogInformation("Attempting to schedule {JobCount} {Type} evaluations", 
                     jobs_to_schedule, processType);
 

--- a/admin/Jobs/EvaluationJobQueue.cs
+++ b/admin/Jobs/EvaluationJobQueue.cs
@@ -31,79 +31,114 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         {
             _logger.LogInformation("Starting evaluation queue check");
             
-            string[] types = new string[]{"MP", "QA", "EM"};
+            string[] processTypes = new string[]{"MP", "QA", "EM"};
 
-            foreach(string type in types){
-                _logger.LogInformation("Checking {Type} evaluations", type);
+            foreach(string processType in processTypes){
+                _logger.LogInformation("Checking {Type} evaluations", processType);
                 
                 List<Evaluation> inQueue = _dbContext.Evaluations.FromSqlRaw(@"
                     SELECT *
                     FROM camdecmpsaux.evaluation_queue
                     WHERE process_cd = {0} AND status_cd = 'QUEUED'
-                    ORDER BY queued_time", type
+                    ORDER BY queued_time", processType
                 ).ToList();
 
                 _logger.LogInformation("Found {Count} {Type} evaluations in QUEUED status", 
-                    inQueue.Count, type);
+                    inQueue.Count, processType);
+
+                // Exit if nothing in queue
+                if (inQueue.Count == 0) continue;
 
                 List<Evaluation> wip = _dbContext.Evaluations.FromSqlRaw(@"
                     SELECT *
                     FROM camdecmpsaux.evaluation_queue
-                    WHERE process_cd = {0} AND status_cd = 'WIP'
-                    ORDER BY queued_time", type
+                    WHERE process_cd = {0} AND status_cd in ('WIP', 'CLAIMED')
+                    ORDER BY queued_time", processType
                 ).ToList();
 
                 _logger.LogInformation("Found {Count} {Type} evaluations in WIP status", 
-                    wip.Count, type);
+                    wip.Count, processType);
 
-                int maxAllowed = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_" + type +"_EVALUATIONS"]);
+                int maxAllowed = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_" + processType +"_EVALUATIONS"]);
                 _logger.LogInformation("Max allowed {Type} evaluations: {MaxAllowed}", 
-                    type, maxAllowed);
+                    processType, maxAllowed);
 
-                if(wip.Count < maxAllowed){
-                    if(inQueue.Count > 0){
-                        int jobs_to_schedule = maxAllowed - wip.Count;
-                        _logger.LogInformation("Attempting to schedule {JobCount} {Type} evaluations", 
-                            jobs_to_schedule, type);
+                // Exit if at max
+                if(wip.Count >= maxAllowed)
+                {
+                  _logger.LogInformation("Maximum number of {Type} evaluations ({MaxAllowed}) already in progress", 
+                      processType, maxAllowed);
+                  continue;
+                }
 
-                        for(int i = 0; i < jobs_to_schedule; i++){
-                            if(i < inQueue.Count){
-                                Evaluation toSchedule = inQueue[i];
-                                _logger.LogInformation("Processing evaluation ID {EvalId}", 
-                                    toSchedule.EvaluationId);
-                                
-                                EvaluationSet es = _dbContext.EvaluationSet.Find(toSchedule.EvaluationSetId);
-                                
-                                _logger.LogInformation("Starting CheckEngineEvaluation for ID {EvalId}", 
-                                    toSchedule.EvaluationId);
-                                await CheckEngineEvaluation.StartNow(
-                                    context.Scheduler,
-                                    toSchedule.EvaluationId,
-                                    es.SetId,
-                                    toSchedule.ProcessCode,
-                                    es.FacId,
-                                    es.FacName,
-                                    es.MonPlanId,
-                                    es.Config,
-                                    es.UserId,
-                                    es.UserEmail,
-                                    toSchedule.QueuedTime,
-                                    toSchedule.TestSumId,
-                                    toSchedule.QaCertEventId,
-                                    toSchedule.TeeId,
-                                    toSchedule.RptPeriod
-                                );
+                int jobs_to_schedule = maxAllowed - wip.Count;
+                _logger.LogInformation("Attempting to schedule {JobCount} {Type} evaluations", 
+                    jobs_to_schedule, processType);
 
-                                int delaySeconds = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_EVALUATION_JOB_QUEUE_DELAY"] ?? "1");
-                                _logger.LogInformation("Waiting {Delay}s before next evaluation", 
-                                    delaySeconds);
-                                Thread.Sleep(delaySeconds * 1000);
-                            }
-                        }
+                // Set to CLAIMED
+                List<Evaluation> claimed = _dbContext.Evaluations
+                  .FromSqlRaw(@"
+                      UPDATE camdecmpsaux.evaluation_queue
+                      SET status_cd = 'CLAIMED'
+                      WHERE evaluation_id IN (
+                          SELECT evaluation_id
+                          FROM camdecmpsaux.evaluation_queue
+                          WHERE process_cd = {0}
+                            AND status_cd = 'QUEUED'
+                          ORDER BY queued_time
+                          LIMIT {1}
+                          FOR UPDATE SKIP LOCKED
+                      )
+                      RETURNING *;",
+                      processType, jobs_to_schedule)
+                  .ToList();
+
+                _logger.LogInformation("Claimed {Count} {Type} evaluations for processing",
+                    claimed.Count, processType);
+
+                foreach(Evaluation toSchedule in claimed){
+                    try
+                    {
+                        _logger.LogInformation("Processing evaluation ID {EvalId}",
+                            toSchedule.EvaluationId);
+
+                        EvaluationSet es = _dbContext.EvaluationSet.Find(toSchedule.EvaluationSetId);
+
+                        _logger.LogInformation("Starting CheckEngineEvaluation for ID {EvalId}",
+                            toSchedule.EvaluationId);
+
+                        await CheckEngineEvaluation.StartNow(
+                            context.Scheduler,
+                            toSchedule.EvaluationId,
+                            es.SetId,
+                            toSchedule.ProcessCode,
+                            es.FacId,
+                            es.FacName,
+                            es.MonPlanId,
+                            es.Config,
+                            es.UserId,
+                            es.UserEmail,
+                            toSchedule.QueuedTime,
+                            toSchedule.TestSumId,
+                            toSchedule.QaCertEventId,
+                            toSchedule.TeeId,
+                            toSchedule.RptPeriod
+                        );
+
+                        int delaySeconds = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_EVALUATION_JOB_QUEUE_DELAY"] ?? "1");
+                        _logger.LogInformation("Waiting {Delay}s before next evaluation",
+                            delaySeconds);
+                        Thread.Sleep(delaySeconds * 1000);
                     }
-                } else {
-                    _logger.LogInformation("Maximum number of {Type} evaluations ({MaxAllowed}) already in progress", 
-                        type, maxAllowed);
+                    catch (Exception e)
+                    {
+                        _logger.LogError("Error starting CheckEngineEvaluation for evaluation ID {EvalId}: {ErrorMessage}",
+                            toSchedule.EvaluationId, e.Message);
+                        // Reset to QUEUED
+                        toSchedule.StatusCode = "QUEUED";
+                        _dbContext.Evaluations.Update(toSchedule);
+                        _dbContext.SaveChanges();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6925

## Main Changes:

- Updated the **`EvaluationJobQueue`** job to set evaluations to the new CLAIMED status prior to initiating a **`CheckEngineEvaluation`** job. This prevents the evaluation from being picked up again by the queue job if it runs again before the evaluation is processed.