### PR TITLE
Fixed email to send record creation to use camel case json attributes

### DIFF
--- a/admin/Jobs/EmailQueueJobs/EmailGroupingStrategies.cs
+++ b/admin/Jobs/EmailQueueJobs/EmailGroupingStrategies.cs
@@ -32,11 +32,22 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs.EmailQueueJobs
     /// </summary>
     public class FacilityContext
     {
+        [JsonProperty("plantName")]
         public string PlantName { get; set; }
+
+        [JsonProperty("locationList")]
         public string LocationList { get; set; }
+
+        [JsonProperty("periodAbbreviation")]
         public string PeriodAbbreviation { get; set; }
+
+        [JsonProperty("plantState")]
         public string PlantState { get; set; }
+
+        [JsonProperty("orisCode")]
         public int OrisCode { get; set; }
+
+        [JsonProperty("windowOpenDate")]
         public string WindowOpenDate { get; set; }
     }
     


### PR DESCRIPTION
Fixed email to send record creation to use camel case json attributes. Fixes compatibility issue between the record creation and the email templates that use them. 