### PR TITLE
#7122  Changes to handle static fields and properties that may not work well with multiple Quartz threads.

### DIFF
--- a/CheckEngine/CheckEngine/SpecialParameterClasses/ComponentOperatingSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/ComponentOperatingSupplementalData.cs
@@ -42,7 +42,11 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Contains the update data table object for supplemental data.
         /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
+        public static DataTable SupplementalDataUpdateDataTable { get => supplementalDataUpdateDataTable; set => supplementalDataUpdateDataTable = value; }
+
+        [ThreadStatic]
+        private static DataTable supplementalDataUpdateDataTable;
+
 
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/DailyCalibrationData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/DailyCalibrationData.cs
@@ -471,12 +471,20 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Contains the update data table object for supplemental data.
         /// </summary>
-        public static DataTable SupplementalDataUpdateLocationDataTable { get; set; }
+        public static DataTable SupplementalDataUpdateLocationDataTable { get => supplementalDataUpdateLocationDataTable; set => supplementalDataUpdateLocationDataTable = value; }
+
+        [ThreadStatic]
+        private static DataTable supplementalDataUpdateLocationDataTable;
+
 
         /// <summary>
         /// Contains the update data table object for supplemental data.
         /// </summary>
-        public static DataTable SupplementalDataUpdateSystemDataTable { get; set; }
+        public static DataTable SupplementalDataUpdateSystemDataTable { get => supplementalDataUpdateSystemDataTable; set => supplementalDataUpdateSystemDataTable = value; }
+
+        [ThreadStatic]
+        private static DataTable supplementalDataUpdateSystemDataTable;
+
 
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/FcValidationInfo.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/FcValidationInfo.cs
@@ -29,12 +29,19 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Contains the minimum non-fuel-specific Fc value for the location.
         /// </summary>
-        static public decimal? NonFuelSpecificMaxValue { get; set; }
+        static public decimal? NonFuelSpecificMaxValue { get => nonFuelSpecificMaxValue; set => nonFuelSpecificMaxValue = value; }
+
+        [ThreadStatic]
+        static private decimal? nonFuelSpecificMaxValue;
+
 
         /// <summary>
         /// Contains the maximum non-fuel-specific Fc value for the location.
         /// </summary>
-        static public decimal? NonFuelSpecificMinValue { get; set; }
+        static public decimal? NonFuelSpecificMinValue { get => nonFuelSpecificMinValue; set => nonFuelSpecificMinValue = value; }
+
+        [ThreadStatic]
+        static private decimal? nonFuelSpecificMinValue;
 
 
         /// <summary>

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/LastQualityAssuredValueSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/LastQualityAssuredValueSupplementalData.cs
@@ -177,7 +177,11 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Contains the update data table object for supplemental data.
         /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
+        public static DataTable SupplementalDataUpdateDataTable { get => supplementalDataUpdateDataTable; set => supplementalDataUpdateDataTable = value; }
+
+        [ThreadStatic]
+        private static DataTable supplementalDataUpdateDataTable;
+
 
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/QaCertificationSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/QaCertificationSupplementalData.cs
@@ -290,12 +290,16 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// </summary>
         public static string QualityAssuredModcList {  get { return "01,02,03,04,14,16,17,19,20,21,22,32,33,41,42,43,44,47,53,54"; } }
 
+
         /// <summary>
         /// Contains the update data table object for supplemental data.
         /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
+        public static DataTable SupplementalDataUpdateDataTable { get => supplementalDataUpdateDataTable; set => supplementalDataUpdateDataTable = value; }
 
-        
+        [ThreadStatic]
+        private static DataTable supplementalDataUpdateDataTable;
+
+
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.
         /// </summary>

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/SamplingTrainEvalInformation.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/SamplingTrainEvalInformation.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 
 
 namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
@@ -36,7 +37,11 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Contains the update data table object for sampling trian supplemental data.
         /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
+        public static DataTable SupplementalDataUpdateDataTable { get => supplementalDataUpdateDataTable; set => supplementalDataUpdateDataTable = value; }
+
+        [ThreadStatic]
+        private static DataTable supplementalDataUpdateDataTable;
+
 
         /// <summary>
         /// Contains the name of the update catalog (database) for sampling trian supplemental data.

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/SystemOperatingSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/SystemOperatingSupplementalData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 
@@ -42,7 +43,11 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Contains the update data table object for supplemental data.
         /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
+        public static DataTable SupplementalDataUpdateDataTable { get => supplementalDataUpdateDataTable; set => supplementalDataUpdateDataTable = value; }
+
+        [ThreadStatic]
+        private static DataTable supplementalDataUpdateDataTable;
+
 
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.

--- a/CheckEngine/DM/Utilities/cCalculator.cs
+++ b/CheckEngine/DM/Utilities/cCalculator.cs
@@ -67,30 +67,37 @@ namespace ECMPS.DM.Utilities
 
     #region Public Properties
 
-    /// <summary>
-    /// Error detail
-    /// </summary>
-    public static string ErrorDetail { get; private set; }
+        /// <summary>
+        /// Error detail
+        /// </summary>
+        public static string ErrorDetail { get => errorDetail; private set => errorDetail = value; }
 
-    /// <summary>
-    /// Unexpected exception trapped by calculator
-    /// </summary>
-    public static Exception TrappedException { get; private set; }
+        [ThreadStatic]
+        private static string errorDetail;
+
+
+        /// <summary>
+        /// Unexpected exception trapped by calculator
+        /// </summary>
+        public static Exception TrappedException { get => trappedException; private set => trappedException = value; }
+
+        [ThreadStatic]
+        private static Exception trappedException;
 
     #endregion
 
 
-    #region Public Methods: Evaluate
+        #region Public Methods: Evaluate
 
-    /// <summary>
-    /// Evaluates a reverse polish notation formula using a set of values where the formula
-    /// indicates the position of the values in the value list using the [#] format where #
-    /// is the position of the value in the value list.
-    /// </summary>
-    /// <param name="equation">Reverse polish notation equation.</param>
-    /// <param name="values">List of values to use in the formula.</param>
-    /// <param name="errorResult">Error enumeration value.</param>
-    /// <returns>Return the result of the evaluation, or null if the evaluation failed.</returns>
+        /// <summary>
+        /// Evaluates a reverse polish notation formula using a set of values where the formula
+        /// indicates the position of the values in the value list using the [#] format where #
+        /// is the position of the value in the value list.
+        /// </summary>
+        /// <param name="equation">Reverse polish notation equation.</param>
+        /// <param name="values">List of values to use in the formula.</param>
+        /// <param name="errorResult">Error enumeration value.</param>
+        /// <returns>Return the result of the evaluation, or null if the evaluation failed.</returns>
     public static decimal? EvaluateReversePolish(string equation, decimal?[] values, out eCalculatorError? errorResult)
     {
       bool failed = false;

--- a/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
+++ b/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
@@ -73,31 +73,141 @@ namespace ECMPS.Checks.DatabaseAccess
         #endregion
 
 
-        #region Public Properties and their associated member variables
+        #region Data Source Static Fields, Dependent Properties, and Helper Field and Method for Locked Updates
 
-        private NpgsqlCommand m_sqlCmd = null;
-        private NpgsqlConnection m_sqlConn = null;
-
-        private int m_nCmdTimeout = 60 * 15;     // 15 minutes
-        private int m_nConnTimeout = 5;         // 5 seconds
-
-        static private string _sDbConnectionString = null;
-
-        // Static data sources for connection pooling efficiency
-        static private NpgsqlDataSource _sqlDataSource = null;
-        static private NpgsqlDataSource _sqlDataSourcePrimary = null;
-        static private NpgsqlDataSource _sqlDataSourceReplica = null;
+        /// <summary>
+        /// Object locked to perform data source changes on a thread.
+        /// </summary>
         static private readonly object _dataSourceLock = new object();
+
+
+        /// <summary>
+        /// Initialize the static data sources for multi-host connection pooling.
+        /// This method is thread-safe and will only initialize once.
+        /// </summary>
+        private static void InitializeDataSources()
+        {
+            // Double-check locking pattern for thread-safe lazy initialization
+            if (_sqlDataSource == null)
+            {
+                lock (_dataSourceLock)
+                {
+                    if (_sqlDataSource == null)
+                    {
+                        try
+                        {
+                            // Create connection string builder to check configuration
+                            var connStrBuilder = new NpgsqlConnectionStringBuilder(_sDbConnectionString);
+
+                            // Determine if multi-host is configured
+                            bool isMultiHost = !string.IsNullOrEmpty(connStrBuilder.Host) && connStrBuilder.Host.Contains(",");
+
+                            if (isMultiHost)
+                            {
+                                // Multi-host: use BuildMultiHost() + WithTargetSession() pattern
+                                var builder = new NpgsqlDataSourceBuilder(_sDbConnectionString);
+                                var multiHostDataSource = builder.BuildMultiHost();
+
+                                // Create wrapped data sources for routing
+                                _sqlDataSourcePrimary = multiHostDataSource.WithTargetSession(TargetSessionAttributes.ReadWrite);
+                                _sqlDataSourceReplica = multiHostDataSource.WithTargetSession(TargetSessionAttributes.PreferStandby);
+
+                                // Keep reference to primary as default
+                                _sqlDataSource = _sqlDataSourcePrimary;
+
+                                LoggerProvider.GetLogger<cDatabase>().LogInformation(
+                                        "Database data sources initialized successfully. Multi-host: True, Primary: ReadWrite, Replica: PreferStandby");
+                            }
+                            else
+                            {
+                                // Single-host: use same data source for both (no replica available)
+                                var builder = new NpgsqlDataSourceBuilder(_sDbConnectionString);
+                                _sqlDataSourcePrimary = builder.Build();
+                                _sqlDataSourceReplica = _sqlDataSourcePrimary;
+                                _sqlDataSource = _sqlDataSourcePrimary;
+
+                                LoggerProvider.GetLogger<cDatabase>().LogInformation(
+                                    "Database data sources initialized successfully. Single-host: using primary for all connections");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            // Log error but don't fail - fallback to direct connection creation
+                            LoggerProvider.GetLogger<cDatabase>().LogError(ex,
+                                "Failed to initialize multi-host data sources. Falling back to single connection mode.");
+                            _sqlDataSource = null;
+                            _sqlDataSourcePrimary = null;
+                            _sqlDataSourceReplica = null;
+                        }
+                    }
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Static data sources for connection pooling efficiency
+        /// </summary>
+        static private NpgsqlDataSource _sqlDataSource;
+
+        /// <summary>
+        /// Primary data source
+        /// </summary>
+        static private NpgsqlDataSource _sqlDataSourcePrimary;
+
+        /// <summary>
+        /// Replication data source
+        /// </summary>
+        static private NpgsqlDataSource _sqlDataSourceReplica;
+
 
         /// <summary>
         /// Indicates whether multi-host configuration is active (derived from data source state)
         /// </summary>
-        public static bool IsMultiHostConfigured =>
-            _sqlDataSourcePrimary != null &&
-            _sqlDataSourceReplica != null &&
-            _sqlDataSourcePrimary != _sqlDataSourceReplica;
+        static public bool IsMultiHostConfigured
+        {
+            get
+            {
+                return _sqlDataSourcePrimary != null &&
+                         _sqlDataSourceReplica != null &&
+                         _sqlDataSourcePrimary != _sqlDataSourceReplica;
+            }
+        }
 
-        private readonly ILogger<cDatabase> _logger = LoggerProvider.GetLogger<cDatabase>();
+        #endregion
+
+
+        #region Static Properties and Supporting Thread Specific Static Variables
+
+        /// <summary>
+        /// Connection string used to connect to ECMPS Data database
+        /// </summary>
+        static public string DbConnectionString
+        {
+            get { return _sDbConnectionString; }
+            set { _sDbConnectionString = value; }
+        }
+
+        [ThreadStatic]
+        static private string _sDbConnectionString = null;
+
+
+        /// <summary>
+        /// Do we show errors, or are we being stealthy?
+        /// </summary>
+        static public bool StealthMode
+        {
+            get { return _bStealth; }
+            set { _bStealth = value; }
+        }
+
+        [ThreadStatic]
+        static private bool _bStealth;
+
+        #endregion
+
+
+        #region Static Fields and Properties
 
         /// <summary>
         /// The default command timeout (15 minutes)
@@ -106,6 +216,19 @@ namespace ECMPS.Checks.DatabaseAccess
         {
             get { return 60 * 15; }
         }
+
+        #endregion
+
+
+        #region Public Properties and their associated member variables
+
+        private NpgsqlCommand m_sqlCmd = null;
+        private NpgsqlConnection m_sqlConn = null;
+
+        private int m_nCmdTimeout = 60 * 15;     // 15 minutes
+        private int m_nConnTimeout = 5;         // 5 seconds
+
+        private readonly ILogger<cDatabase> _logger = LoggerProvider.GetLogger<cDatabase>();
 
         // Internal Error Variables
 
@@ -122,17 +245,6 @@ namespace ECMPS.Checks.DatabaseAccess
         /// The last error generated by this class
         /// </summary>
         private string m_sLastError = "";
-
-        static private bool _bStealth = false;
-
-        /// <summary>
-        /// Do we show errors, or are we being stealthy?
-        /// </summary>
-        public static bool StealthMode
-        {
-            get { return _bStealth; }
-            set { _bStealth = value; }
-        }
 
         /// <summary>
         /// The NpgsqlClient.Command object
@@ -161,15 +273,6 @@ namespace ECMPS.Checks.DatabaseAccess
                     return ConnectionState.Closed;
                 return m_sqlConn.State;
             }
-        }
-
-        /// <summary>
-        /// Connection string used to connect to ECMPS Data database
-        /// </summary>
-        static public string DbConnectionString
-        {
-            get { return _sDbConnectionString; }
-            set { _sDbConnectionString = value; }
         }
 
         /// <summary>
@@ -253,69 +356,6 @@ namespace ECMPS.Checks.DatabaseAccess
             set
             {
                 m_nConnTimeout = value;
-            }
-        }
-
-        /// <summary>
-        /// Initialize the static data sources for multi-host connection pooling.
-        /// This method is thread-safe and will only initialize once.
-        /// </summary>
-        private static void InitializeDataSources()
-        {
-            // Double-check locking pattern for thread-safe lazy initialization
-            if (_sqlDataSource == null)
-            {
-                lock (_dataSourceLock)
-                {
-                    if (_sqlDataSource == null)
-                    {
-                        try
-                        {
-                            // Create connection string builder to check configuration
-                            var connStrBuilder = new NpgsqlConnectionStringBuilder(_sDbConnectionString);
-
-                            // Determine if multi-host is configured
-                            bool isMultiHost = !string.IsNullOrEmpty(connStrBuilder.Host) && connStrBuilder.Host.Contains(",");
-
-                            if (isMultiHost)
-                            {
-                                // Multi-host: use BuildMultiHost() + WithTargetSession() pattern
-                                var builder = new NpgsqlDataSourceBuilder(_sDbConnectionString);
-                                var multiHostDataSource = builder.BuildMultiHost();
-
-                                // Create wrapped data sources for routing
-                                _sqlDataSourcePrimary = multiHostDataSource.WithTargetSession(TargetSessionAttributes.ReadWrite);
-                                _sqlDataSourceReplica = multiHostDataSource.WithTargetSession(TargetSessionAttributes.PreferStandby);
-
-                            // Keep reference to primary as default
-                            _sqlDataSource = _sqlDataSourcePrimary;
-
-                            LoggerProvider.GetLogger<cDatabase>().LogInformation(
-                                    "Database data sources initialized successfully. Multi-host: True, Primary: ReadWrite, Replica: PreferStandby");
-                            }
-                            else
-                            {
-                                // Single-host: use same data source for both (no replica available)
-                                var builder = new NpgsqlDataSourceBuilder(_sDbConnectionString);
-                                _sqlDataSourcePrimary = builder.Build();
-                                _sqlDataSourceReplica = _sqlDataSourcePrimary;
-                                _sqlDataSource = _sqlDataSourcePrimary;
-
-                                LoggerProvider.GetLogger<cDatabase>().LogInformation(
-                                    "Database data sources initialized successfully. Single-host: using primary for all connections");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            // Log error but don't fail - fallback to direct connection creation
-                            LoggerProvider.GetLogger<cDatabase>().LogError(ex,
-                                "Failed to initialize multi-host data sources. Falling back to single connection mode.");
-                            _sqlDataSource = null;
-                            _sqlDataSourcePrimary = null;
-                            _sqlDataSourceReplica = null;
-                        }
-                    }
-                }
             }
         }
 
@@ -2553,6 +2593,7 @@ namespace ECMPS.Checks.DatabaseAccess
 
         #region Public Static Methods: Severity Code
 
+        [ThreadStatic]
         private static DataView m_dvSeverityCode = null;
 
         /// <summary>

--- a/CheckEngine/Emissions/EmissionReport/Checks/HourlyOperatingDataChecks.cs
+++ b/CheckEngine/Emissions/EmissionReport/Checks/HourlyOperatingDataChecks.cs
@@ -2223,14 +2223,7 @@ namespace ECMPS.Checks.EmissionsChecks
 
 
                             // Initialize fcValidationInfo to the general Fc range.
-                            {
-                                FFactorRangeChecksRow fFactorRangeChecksRow = emParams.FFactorRangeCrossCheckTable.FindRow(new cFilterCondition("Factor", "FC"));
-
-                                decimal minValue = (fFactorRangeChecksRow != null) ? fFactorRangeChecksRow.LowerValue.AsDecimal().Default(Decimal.MinValue) : Decimal.MinValue;
-                                decimal maxValue = (fFactorRangeChecksRow != null) ? fFactorRangeChecksRow.UpperValue.AsDecimal().Default(Decimal.MaxValue) : Decimal.MaxValue;
-
-                                fcValidationInfo = new FcValidationInfo(FcValidationInfo.NonFuelSpecificMinValue.Value, FcValidationInfo.NonFuelSpecificMaxValue.Value);
-                            }
+                            fcValidationInfo = new FcValidationInfo(FcValidationInfo.NonFuelSpecificMinValue.Value, FcValidationInfo.NonFuelSpecificMaxValue.Value);
 
 
                             if (!otherFound)

--- a/CheckEngine/Emissions/EmissionReport/EmissionsReportProcess.cs
+++ b/CheckEngine/Emissions/EmissionReport/EmissionsReportProcess.cs
@@ -4612,76 +4612,48 @@ namespace ECMPS.Checks.EmissionsReport
         /// <param name="errorMessage">The error message returned on failure.</param>
         /// <returns>Returns true if the update succeeds.</returns>
         protected override bool DbUpdate_CalcWsLoad(NpgsqlTransaction sqlTransaction, ref string errorMessage)
-        {            
-            DataTable[] sourceTables = new DataTable[]
-            {FCalcDailyCal, FCalcDailyTestSummary, FCalcDerivedHrlyValue, FCalcMonitorHrlyValue, FCalcHrlyFuelFlow, FCalcHrlyParamFuelFlow, FCalcLongTermFuelFlow, FCalcDailyEmission, FCalcDailyFuel, FCalcSummaryValue, CalcMATSDHVData, CalcMATSMHVData,
-            CalcHrlyGasFlowMeter, CalcSamplingTrain, CalcSorbentTrap, SamplingTrainEvalInformation.SupplementalDataUpdateDataTable, CalcWeeklyTestSummary, CalcWeeklySystemIntegrity, QaCertificationSupplementalData.SupplementalDataUpdateDataTable,
-            SystemOperatingSupplementalData.SupplementalDataUpdateDataTable, ComponentOperatingSupplementalData.SupplementalDataUpdateDataTable, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateDataTable,
-            cDailyCalibrationData.SupplementalDataUpdateLocationDataTable, cDailyCalibrationData.SupplementalDataUpdateSystemDataTable};
-            
-            string[] tableLocation = new string[]{"camdecmpscalc.daily_calibration", "camdecmpscalc.daily_test_summary", "camdecmpscalc.derived_hrly_value", "camdecmpscalc.monitor_hrly_value", "camdecmpscalc.hrly_param_fuel_flow", "camdecmpscalc.long_term_fuel_flow",
-            "camdecmpscalc.daily_emission", "camdecmpscalc.daily_fuel", "camdecmpscalc.summary_value", "camdecmpscalc.mats_derived_hrly_value", "camdecmpscalc.mats_monitor_hrly_value", "camdecmpscalc.hrly_gas_flow_meter", "camdecmpscalc.sampling_train","camdecmpscalc.sorbent_trap",
-            SamplingTrainEvalInformation.SupplementalDataUpdateTableName, "camdecmpscalc.weekly_test_summary", "camdecmpscalc.weekly_system_integrity", QaCertificationSupplementalData.SupplementalDataUpdateTablePath, SystemOperatingSupplementalData.SupplementalDataUpdateTablePath,
-            ComponentOperatingSupplementalData.SupplementalDataUpdateTablePath, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateTablePath, cDailyCalibrationData.SupplementalDataUpdateLocationTablePath, cDailyCalibrationData.SupplementalDataUpdateSystemTablePath};
-
-            
+        {
             bool result;
-            /*
-            for(int i = 0; i < sourceTables.Length; i++){
-                Task.Run(() => 
-                {
-                    result = DbConnection.BulkLoad(sourceTables[i], tableLocation[i], ref errorMessage);    
-                } );
-            }
-            */
 
-            //if (mCheckEngine.DbConnection.ClearUpdateSession(eWorkspaceDataType.EM, mCheckEngine.ChkSessionId))
-            //{
             if (
-                        DbConnection.BulkLoad(FCalcDailyCal, "camdecmpscalc.daily_calibration", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcDailyTestSummary, "camdecmpscalc.daily_test_summary", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcDerivedHrlyValue, "camdecmpscalc.derived_hrly_value", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcMonitorHrlyValue, "camdecmpscalc.monitor_hrly_value", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcHrlyFuelFlow, "camdecmpscalc.hrly_fuel_flow", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcHrlyParamFuelFlow, "camdecmpscalc.hrly_param_fuel_flow", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcLongTermFuelFlow, "camdecmpscalc.long_term_fuel_flow", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcDailyEmission, "camdecmpscalc.daily_emission", ref errorMessage) &&
-                        DbConnection.BulkLoad(FCalcDailyFuel, "camdecmpscalc.daily_fuel", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcDailyCal, "camdecmpscalc.daily_calibration", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcDailyTestSummary, "camdecmpscalc.daily_test_summary", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcDerivedHrlyValue, "camdecmpscalc.derived_hrly_value", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcMonitorHrlyValue, "camdecmpscalc.monitor_hrly_value", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcHrlyFuelFlow, "camdecmpscalc.hrly_fuel_flow", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcHrlyParamFuelFlow, "camdecmpscalc.hrly_param_fuel_flow", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcLongTermFuelFlow, "camdecmpscalc.long_term_fuel_flow", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcDailyEmission, "camdecmpscalc.daily_emission", ref errorMessage) &&
+                    DbConnection.BulkLoad(FCalcDailyFuel, "camdecmpscalc.daily_fuel", ref errorMessage) &&
 
-                        DbConnection.BulkLoad(FOperatingSuppData, "camdecmpscalc.operating_supp_data", ref errorMessage) &&
+                    DbConnection.BulkLoad(FOperatingSuppData, "camdecmpscalc.operating_supp_data", ref errorMessage) &&
 
-                        DbConnection.BulkLoad(FCalcSummaryValue, "camdecmpscalc.summary_value", ref errorMessage) &&
-                        DbConnection.BulkLoad(CalcMATSDHVData, "camdecmpscalc.mats_derived_hrly_value", ref errorMessage) &&
-                        DbConnection.BulkLoad(CalcMATSMHVData, "camdecmpscalc.mats_monitor_hrly_value", ref errorMessage) &&
-                        /* Sorbent Trap Related */
-                        DbConnection.BulkLoad(CalcHrlyGasFlowMeter, "camdecmpscalc.hrly_gas_flow_meter", ref errorMessage) &&
-                        DbConnection.BulkLoad(CalcSamplingTrain, "camdecmpscalc.sampling_train", ref errorMessage) &&
-                        DbConnection.BulkLoad(CalcSorbentTrap, "camdecmpscalc.sorbent_trap", ref errorMessage) &&
-                        /* Sampling Train Supplemental Data*/
-                        DbConnection.BulkLoad(SamplingTrainEvalInformation.SupplementalDataUpdateDataTable,
-                                                SamplingTrainEvalInformation.SupplementalDataUpdateTablePath,
-                                                ref errorMessage) &&
-                        /* Weekly Emission Tests */
-                        DbConnection.BulkLoad(CalcWeeklyTestSummary, "camdecmpscalc.weekly_test_summary", ref errorMessage) &&
-                        DbConnection.BulkLoad(CalcWeeklySystemIntegrity, "camdecmpscalc.weekly_system_integrity", ref errorMessage) &&
-                        /* Supplemental Data*/
-                        DbConnection.BulkLoad(QaCertificationSupplementalData.SupplementalDataUpdateDataTable, QaCertificationSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(SystemOperatingSupplementalData.SupplementalDataUpdateDataTable, SystemOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(ComponentOperatingSupplementalData.SupplementalDataUpdateDataTable, ComponentOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(LastQualityAssuredValueSupplementalData.SupplementalDataUpdateDataTable, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(cDailyCalibrationData.SupplementalDataUpdateLocationDataTable, cDailyCalibrationData.SupplementalDataUpdateLocationTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(cDailyCalibrationData.SupplementalDataUpdateSystemDataTable, cDailyCalibrationData.SupplementalDataUpdateSystemTablePath, ref errorMessage) &&
-                        cLastDailyInterferenceCheck.SaveSupplementalData(LatesDailyInterferenceCheckObject, CheckEngine.RptPeriodId.Value, CheckEngine.ChkSessionId, DbConnection, ref errorMessage)
-                   )
-                    result = true;
-                else
-                    result = false;
-            //}
-            //else
-            //{
-                //errorMessage = mCheckEngine.DbWsConnection.LastError;
-                //result = false;
-            //}
+                    DbConnection.BulkLoad(FCalcSummaryValue, "camdecmpscalc.summary_value", ref errorMessage) &&
+                    DbConnection.BulkLoad(CalcMATSDHVData, "camdecmpscalc.mats_derived_hrly_value", ref errorMessage) &&
+                    DbConnection.BulkLoad(CalcMATSMHVData, "camdecmpscalc.mats_monitor_hrly_value", ref errorMessage) &&
+                    /* Sorbent Trap Related */
+                    DbConnection.BulkLoad(CalcHrlyGasFlowMeter, "camdecmpscalc.hrly_gas_flow_meter", ref errorMessage) &&
+                    DbConnection.BulkLoad(CalcSamplingTrain, "camdecmpscalc.sampling_train", ref errorMessage) &&
+                    DbConnection.BulkLoad(CalcSorbentTrap, "camdecmpscalc.sorbent_trap", ref errorMessage) &&
+                    /* Sampling Train Supplemental Data*/
+                    DbConnection.BulkLoad(SamplingTrainEvalInformation.SupplementalDataUpdateDataTable,
+                                          SamplingTrainEvalInformation.SupplementalDataUpdateTablePath,
+                                          ref errorMessage) &&
+                    /* Weekly Emission Tests */
+                    DbConnection.BulkLoad(CalcWeeklyTestSummary, "camdecmpscalc.weekly_test_summary", ref errorMessage) &&
+                    DbConnection.BulkLoad(CalcWeeklySystemIntegrity, "camdecmpscalc.weekly_system_integrity", ref errorMessage) &&
+                    /* Supplemental Data*/
+                    DbConnection.BulkLoad(QaCertificationSupplementalData.SupplementalDataUpdateDataTable, QaCertificationSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                    DbConnection.BulkLoad(SystemOperatingSupplementalData.SupplementalDataUpdateDataTable, SystemOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                    DbConnection.BulkLoad(ComponentOperatingSupplementalData.SupplementalDataUpdateDataTable, ComponentOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                    DbConnection.BulkLoad(LastQualityAssuredValueSupplementalData.SupplementalDataUpdateDataTable, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                    DbConnection.BulkLoad(cDailyCalibrationData.SupplementalDataUpdateLocationDataTable, cDailyCalibrationData.SupplementalDataUpdateLocationTablePath, ref errorMessage) &&
+                    DbConnection.BulkLoad(cDailyCalibrationData.SupplementalDataUpdateSystemDataTable, cDailyCalibrationData.SupplementalDataUpdateSystemTablePath, ref errorMessage) &&
+                    cLastDailyInterferenceCheck.SaveSupplementalData(LatesDailyInterferenceCheckObject, CheckEngine.RptPeriodId.Value, CheckEngine.ChkSessionId, DbConnection, ref errorMessage)
+               )
+                result = true;
+            else
+                result = false;
 
             return result;
         }

--- a/CheckEngine/TypeUtilities/DateFunctions.cs
+++ b/CheckEngine/TypeUtilities/DateFunctions.cs
@@ -23,7 +23,8 @@ namespace ECMPS.Checks.TypeUtilities
         {
         }
 
-        private static DataTable FReportingPeriodTable = null;
+        [ThreadStatic]
+        private static DataTable FReportingPeriodTable;
 
         /// <summary>
         /// Returns the current Reporting Period Table

--- a/CheckEngine/TypeUtilities/DecimalPrecision.cs
+++ b/CheckEngine/TypeUtilities/DecimalPrecision.cs
@@ -55,6 +55,7 @@ namespace ECMPS.Checks.TypeUtilities
 
     }
 
+    [ThreadStatic]
     private static cHandleDecimalPrecision[] FDecimalPrecision;
 
     /// <summary>

--- a/CheckEngine/TypeUtilities/DistinctHourRanges.cs
+++ b/CheckEngine/TypeUtilities/DistinctHourRanges.cs
@@ -58,13 +58,19 @@ namespace ECMPS.Checks.TypeUtilities
         /// <summary>
         /// The maximum hour with date for Distinct Hour Ranges.
         /// </summary>
-        public static DateTime MaxHour { get; private set; }
+        public static DateTime MaxHour { get => maxHour; private set => maxHour = value; }
+
+        [ThreadStatic]
+        private static DateTime maxHour;
 
 
         /// <summary>
         /// The minimum hour with date for Distinct Hour Ranges.
         /// </summary>
-        public static DateTime MinHour { get; private set; }
+        public static DateTime MinHour { get => minHour; private set=> minHour = value; }
+
+        [ThreadStatic]
+        private static DateTime minHour;
 
 
         /// <summary>

--- a/CheckEngine/TypeUtilities/Quarter.cs
+++ b/CheckEngine/TypeUtilities/Quarter.cs
@@ -57,7 +57,10 @@ namespace ECMPS.Checks.TypeUtilities
 				throw new ArgumentOutOfRangeException("quarterKey", quarterKey, "quarterKey must be greater than or equal to 5 to represent the minimum of year 1 AD, quarter 1.");
 			}
 
-			if (!QuarterDictionary.ContainsKey(quarterKey))
+            if (QuarterDictionary == null)
+                QuarterDictionary = new Dictionary<int, Quarter>();
+
+            if (!QuarterDictionary.ContainsKey(quarterKey))
 			{
 				new Quarter(quarterKey); // Automatically added to QuarterDictionary
 			}

--- a/CheckEngine/TypeUtilities/Quarter.cs
+++ b/CheckEngine/TypeUtilities/Quarter.cs
@@ -21,7 +21,11 @@ namespace ECMPS.Checks.TypeUtilities
 		/// <exception cref="System.ArgumentOutOfRangeException">Thrown when quarterKey represents a quarter before year 1 AD, quarter 1.</exception>
 		private Quarter(int quarterKey)
 		{
-			if (QuarterDictionary.ContainsKey(quarterKey))
+			if (QuarterDictionary == null)
+				QuarterDictionary = new Dictionary<int, Quarter>();
+
+
+            if (QuarterDictionary.ContainsKey(quarterKey))
 				throw new ArgumentException( $"A Quarter object was previously created for quarterKey {quarterKey}.", "quarterKey");
 			if (quarterKey < 5)
 				throw new ArgumentOutOfRangeException("quarterKey", quarterKey, "quarterKey must be greater than or equal to 5 to represent the minimum of year 1 AD, quarter 1.");
@@ -102,12 +106,13 @@ namespace ECMPS.Checks.TypeUtilities
 			return FetchQuarter(quarterKey.Value);
 		}
 
-        #endregion
+		#endregion
 
 
-        #region Private Statuc Fields
+		#region Private Statuc Fields
 
-        private static Dictionary<int, Quarter> QuarterDictionary = new Dictionary<int, Quarter>();
+		[ThreadStatic]
+        private static Dictionary<int, Quarter> QuarterDictionary;
 
 		#endregion
 

--- a/CheckEngine/TypeUtilities/ReportingPeriod.cs
+++ b/CheckEngine/TypeUtilities/ReportingPeriod.cs
@@ -338,6 +338,7 @@ namespace ECMPS.Checks.TypeUtilities
     /// <summary>
     /// Contains the lookup table used to read reporting period information.
     /// </summary>
+    [ThreadStatic]
     protected static DataTable FLookupTable = null;
 
     #endregion


### PR DESCRIPTION
## Direct Changes Involving [ThreadStatic] Attribute

The changes involved either applying [ThreadStatic] to a static field or creating a static field with [ThreadStatic] and using it in a static property.

- CheckEngine/SpecialParameterClasses:

  - ComponentOperatingSupplementalData.cs
  - DailyCalibrationData.cs
  - FcValidationInfo.cs
    - Updated HOUROP-34 in HourlyOperatingDataChecks.cs to eliminated unused logic associated with the FcValidationInfo static properties.
  - LastQualityAssuredValueSupplementalData.cs
  - QaCertificationSupplementalData.cs
  - SamplingTrainEvalInformation.cs
  - SystemOperatingSupplementalData.cs
- DM/Utilities
  - cCalculator.cs
- TypeUtilities
  - DateFunctions.cs
  - DecimalPrecision.cs
  - DistinctHourRanges.cs
  - Quarter.cs
    - Includes the initialization of the static field which can nolonger occur inline with the declaration when [ThreadStatic] is used.
  - ReportingPeriod.cs

## Changes to DatabaseAccess/cNpgsqlServer.cs

1. Includes [ThreadStatic] attribute changes.  Some were moved to a common region.
2. Fields, Methods and Properties associated with using a lock to implement thread safety were moved to a single region.
3. Other unchanged static fields and properties where moved to a single region.

## Changes to Emissions/RemissionReport/EmissionsReportProcess.cs

Removed unused variables and related commented out code.
