### PR TITLE
Fix/#7122 replace static fields and properties

### DIFF
--- a/CheckEngine/CheckEngine/CheckEngine.cs
+++ b/CheckEngine/CheckEngine/CheckEngine.cs
@@ -99,8 +99,6 @@ namespace ECMPS.Checks.CheckEngine
                             string systemStateDumpFilePath,
                             int? commandTimeout)
         {
-            cDecimalPrecision.Initialize();
-
             UserId = userId;
 
             DbConnectionString = dataConnectionString;

--- a/CheckEngine/CheckEngine/Definitions/cExtensions.cs
+++ b/CheckEngine/CheckEngine/Definitions/cExtensions.cs
@@ -25,7 +25,7 @@ namespace ECMPS.Checks.CheckEngine.Definitions
 
         #region Severity Code
 
-        private static DataView _dvSeverityCode = null;
+        private static readonly DataView _dvSeverityCode = RetrieveSeverityCodeData();
 
         /// <summary>
         /// Returns whether the passed Severity Code will block submissions
@@ -34,7 +34,7 @@ namespace ECMPS.Checks.CheckEngine.Definitions
         /// <returns>true if the severity code blocks submission, otherwise false</returns>
         public static bool BlocksSubmission(this eSeverityCd ASeverityCd)
         {
-            if ((_dvSeverityCode != null) || LoadSeverityCode())
+            if (_dvSeverityCode != null)
             {
                 DataRowView SeverityRow = GetSeverityRow(ASeverityCd.ToStringValue());
 
@@ -54,7 +54,7 @@ namespace ECMPS.Checks.CheckEngine.Definitions
         {
             string Result = ADefault;
 
-            if ((_dvSeverityCode != null) || LoadSeverityCode())
+            if (_dvSeverityCode != null)
             {
                 DataRowView SeverityRow = GetSeverityRow(ASeverityCd.ToStringValue());
 
@@ -85,7 +85,7 @@ namespace ECMPS.Checks.CheckEngine.Definitions
         {
             int Result = ADefault;
 
-            if ((_dvSeverityCode != null) || LoadSeverityCode())
+            if (_dvSeverityCode != null)
             {
                 DataRowView SeverityRow = GetSeverityRow(ASeverityCd.ToStringValue());
 
@@ -125,12 +125,13 @@ namespace ECMPS.Checks.CheckEngine.Definitions
         }
 
         /// <summary>
-        /// Load the severity code table, _dvSeverityCode, if successful
+        /// Returns the severity code table if .
         /// </summary>
-        /// <returns>true if successful, false if an error</returns>
-        private static bool LoadSeverityCode()
+        /// <returns>DataView if successful, null if an error</returns>
+        private static DataView RetrieveSeverityCodeData()
         {
-            bool bRetVal = false;
+            DataView result;
+
             string sql = "select Severity_Cd, Severity_Cd_Description, Severity_Level, 0 as Blocks_Submission from camdecmpsmd.severity_code";
             // Use replica db: camdecmpsmd.severity_code is read-only reference data
             cDatabase dbConnection = cDatabase.GetConnection("LoadSeverityCode", cDatabase.eDatabaseTarget.READONLY);
@@ -138,8 +139,8 @@ namespace ECMPS.Checks.CheckEngine.Definitions
             try
             {
                 DataTable dtSeverityCode = dbConnection.GetDataTable(sql);
-                _dvSeverityCode = new DataView(dtSeverityCode, null, "Severity_Cd", DataViewRowState.CurrentRows);
-                foreach (DataRowView drSeverityCode in _dvSeverityCode)
+                result = new DataView(dtSeverityCode, null, "Severity_Cd", DataViewRowState.CurrentRows);
+                foreach (DataRowView drSeverityCode in result)
                 {
                     string sSeverityCd = cDBConvert.ToString(drSeverityCode["severity_cd"]);
                     if (sSeverityCd == eSeverityCd.FATAL.ToStringValue() ||
@@ -147,17 +148,16 @@ namespace ECMPS.Checks.CheckEngine.Definitions
                         sSeverityCd == eSeverityCd.EXCEPTION.ToStringValue())
                         drSeverityCode["Blocks_Submission"] = 1;
                 }
-                bRetVal = true;
             }
             catch (Exception ex)
             {
-                _dvSeverityCode = null;
+                result = null;
                 _logger.LogError(ex, "Loading of SEVERITY_CODE view failed");
-                bRetVal = false;
             }
 
             dbConnection.Close();
-            return bRetVal;
+
+            return result;
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace ECMPS.Checks.CheckEngine.Definitions
         public static eSeverityCd ToSeverityCd(this string SeverityCode)
         {
             eSeverityCd SeverityCd = eSeverityCd.NONE;
-            if ((_dvSeverityCode != null) || LoadSeverityCode())
+            if (_dvSeverityCode != null)
             {
                 DataRowView SeverityRow = GetSeverityRow(SeverityCode);
 

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/ComponentOperatingSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/ComponentOperatingSupplementalData.cs
@@ -58,13 +58,13 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
-        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
         /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
         /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
-        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, ComponentOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
+        /// <returns>The updated SupplementalDataUpdateDataTable.</returns>
+        public static DataTable LoadSupplementalDataUpdateDataTable(Dictionary<string, ComponentOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            DataTable supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
             if (supplementalDataUpdateDataTable != null)
             {
@@ -76,6 +76,8 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
                     }
                 }
             }
+
+            return supplementalDataUpdateDataTable;
         }
 
         #endregion

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/ComponentOperatingSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/ComponentOperatingSupplementalData.cs
@@ -40,11 +40,6 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         #region Static Properties and Methods
 
         /// <summary>
-        /// Contains the update data table object for supplemental data.
-        /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
-
-        /// <summary>
         /// Contains the name of the update schema for the supplemental data.
         /// </summary>
         public static string SupplementalDataUpdateSchemaName { get { return "camdecmpscalc"; } }
@@ -63,18 +58,21 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
-        public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, ComponentOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
-      // public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, ComponentOperatingSupplementalData>[] supplementalDataDictionaryArray, decimal workspaceSessionId, SqlConnection connection)
+        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
+        /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
+        /// <param name="checkSessionId">The workspace session id for check session.</param>
+        /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
+        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, ComponentOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            SupplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
-            if (SupplementalDataUpdateDataTable != null)
+            if (supplementalDataUpdateDataTable != null)
             {
                 foreach (Dictionary<string, ComponentOperatingSupplementalData> supplementalDataDictionary in supplementalDataDictionaryArray)
                 {
                     foreach (OperatingSupplementalData supplementalData in supplementalDataDictionary.Values)
                     {
-                        LoadSupplementalDataUpdateDataDoRow(supplementalData, "COMPONENT_ID", SupplementalDataUpdateDataTable, checkSessionId);
+                        LoadSupplementalDataUpdateDataDoRow(supplementalData, "COMPONENT_ID", supplementalDataUpdateDataTable, checkSessionId);
                     }
                 }
             }

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/DailyCalibrationData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/DailyCalibrationData.cs
@@ -374,20 +374,21 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Updates the supplemental data load tables for each component.
         /// </summary>
-        /// <param name="rptPeriodId"></param>
-        /// <param name="checkSessionId"></param>
-        /// <param name="connection"></param>
-        public void LoadIntoSupplementalDataTables(int rptPeriodId, string checkSessionId, NpgsqlConnection connection)
-        //public void LoadIntoSupplementalDataTables(int rptPeriodId, decimal workspaceSessionId, SqlConnection connection)
+        /// <param name="supplementalDataUpdateLocationDataTable">The location level SupplementalDataUpdateDataTable to udpate.</param>
+        /// <param name="supplementalDataUpdateSystemDataTable">The system level SupplementalDataUpdateDataTable to udpate.</param>
+        /// <param name="rptPeriodId">The reporting period id for the emission file.</param>
+        /// <param name="checkSessionId">The workspace session id for check session.</param>
+        /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
+        public void LoadIntoSupplementalDataTables(DataTable supplementalDataUpdateLocationDataTable, DataTable supplementalDataUpdateSystemDataTable, int rptPeriodId, string checkSessionId, NpgsqlConnection connection)
         {
-            SupplementalDataUpdateLocationDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateLocationTableName, connection);
-            SupplementalDataUpdateSystemDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateSystemTableName, connection);
+            supplementalDataUpdateLocationDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateLocationTableName, connection);
+            supplementalDataUpdateSystemDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateSystemTableName, connection);
 
-            if ((SupplementalDataUpdateLocationDataTable != null) && (SupplementalDataUpdateSystemDataTable != null))
+            if ((supplementalDataUpdateLocationDataTable != null) && (supplementalDataUpdateSystemDataTable != null))
             {
                 foreach (string componentId in ComponentData.Keys)
                 {
-                    ComponentData[componentId].LoadIntoSupplementalDataTables(SupplementalDataUpdateLocationDataTable, SupplementalDataUpdateSystemDataTable, rptPeriodId, checkSessionId);
+                    ComponentData[componentId].LoadIntoSupplementalDataTables(supplementalDataUpdateLocationDataTable, supplementalDataUpdateSystemDataTable, rptPeriodId, checkSessionId);
                 }
             }
         }
@@ -467,16 +468,6 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
 
 
         #region Static Properties
-
-        /// <summary>
-        /// Contains the update data table object for supplemental data.
-        /// </summary>
-        public static DataTable SupplementalDataUpdateLocationDataTable { get; set; }
-
-        /// <summary>
-        /// Contains the update data table object for supplemental data.
-        /// </summary>
-        public static DataTable SupplementalDataUpdateSystemDataTable { get; set; }
 
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/DailyCalibrationData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/DailyCalibrationData.cs
@@ -379,7 +379,7 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <param name="rptPeriodId">The reporting period id for the emission file.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
         /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
-        public void LoadIntoSupplementalDataTables(DataTable supplementalDataUpdateLocationDataTable, DataTable supplementalDataUpdateSystemDataTable, int rptPeriodId, string checkSessionId, NpgsqlConnection connection)
+        public void LoadIntoSupplementalDataTables(out DataTable supplementalDataUpdateLocationDataTable, out DataTable supplementalDataUpdateSystemDataTable, int rptPeriodId, string checkSessionId, NpgsqlConnection connection)
         {
             supplementalDataUpdateLocationDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateLocationTableName, connection);
             supplementalDataUpdateSystemDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateSystemTableName, connection);

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/FcValidationInfo.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/FcValidationInfo.cs
@@ -27,17 +27,6 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
 
 
         /// <summary>
-        /// Contains the minimum non-fuel-specific Fc value for the location.
-        /// </summary>
-        static public decimal? NonFuelSpecificMaxValue { get; set; }
-
-        /// <summary>
-        /// Contains the maximum non-fuel-specific Fc value for the location.
-        /// </summary>
-        static public decimal? NonFuelSpecificMinValue { get; set; }
-
-
-        /// <summary>
         /// Indicates whether the Fc value range is fueld specific.
         /// </summary>
         public bool IsFuelSpecific { get; private set; }

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/LastQualityAssuredValueSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/LastQualityAssuredValueSupplementalData.cs
@@ -173,12 +173,6 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// </summary>
         public static string QualityAssuredModcList { get { return "01,02,03,04,14,16,17,19,20,21,22,47,53,54"; } }
 
-
-        /// <summary>
-        /// Contains the update data table object for supplemental data.
-        /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
-
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.
         /// </summary>
@@ -198,22 +192,21 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
+        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
         /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
         /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
-        public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, LastQualityAssuredValueSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
-
-        // public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, LastQualityAssuredValueSupplementalData>[] supplementalDataDictionaryArray, decimal workspaceSessionId, SqlConnection connection)
+        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, LastQualityAssuredValueSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            SupplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
-            if (SupplementalDataUpdateDataTable != null)
+            if (supplementalDataUpdateDataTable != null)
             {
                 foreach (Dictionary<string, LastQualityAssuredValueSupplementalData> supplementalDataDictionary in supplementalDataDictionaryArray)
                 {
                     foreach (LastQualityAssuredValueSupplementalData supplementalData in supplementalDataDictionary.Values)
                     {
-                        DataRow dataRow = SupplementalDataUpdateDataTable.NewRow();
+                        DataRow dataRow = supplementalDataUpdateDataTable.NewRow();
 
                         dataRow["CHK_SESSION_ID"] = checkSessionId;
                         dataRow["MON_LOC_ID"] = supplementalData.MonLocId;
@@ -235,7 +228,7 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
                         else
                             dataRow["ADJUSTED_HRLY_VALUE"] = DBNull.Value;
 
-                        SupplementalDataUpdateDataTable.Rows.Add(dataRow);
+                        supplementalDataUpdateDataTable.Rows.Add(dataRow);
                     }
                 }
             }

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/LastQualityAssuredValueSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/LastQualityAssuredValueSupplementalData.cs
@@ -192,13 +192,13 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
-        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
         /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
         /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
-        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, LastQualityAssuredValueSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
+        /// <returns>The updated SupplementalDataUpdateDataTable.</returns>
+        public static DataTable LoadSupplementalDataUpdateDataTable(Dictionary<string, LastQualityAssuredValueSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            DataTable supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
             if (supplementalDataUpdateDataTable != null)
             {
@@ -232,6 +232,8 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
                     }
                 }
             }
+
+            return supplementalDataUpdateDataTable;
         }
 
         #endregion

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/QaCertificationSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/QaCertificationSupplementalData.cs
@@ -289,12 +289,6 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// The list of MODC for quality assured hours.
         /// </summary>
         public static string QualityAssuredModcList {  get { return "01,02,03,04,14,16,17,19,20,21,22,32,33,41,42,43,44,47,53,54"; } }
-
-        /// <summary>
-        /// Contains the update data table object for supplemental data.
-        /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
-
         
         /// <summary>
         /// Contains the name of the update schema for the supplemental data.
@@ -315,12 +309,15 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
-        public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, QaCertificationSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
-        // public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, QaCertificationSupplementalData>[] supplementalDataDictionaryArray, decimal workspaceSessionId, SqlConnection connection)
+        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
+        /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
+        /// <param name="checkSessionId">The workspace session id for check session.</param>
+        /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
+        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, QaCertificationSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            SupplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
-            if (SupplementalDataUpdateDataTable != null)
+            if (supplementalDataUpdateDataTable != null)
             {
                 string suppDateCd;
 
@@ -338,34 +335,34 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
                         if (suppDateCd != null)
                         {
                             if (supplementalData.QuarterlyOperatingCounts != null)
-                                LoadSupplementalDataUpdateDataRow("OP", suppDateCd, supplementalData.QuarterlyOperatingCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("OP", suppDateCd, supplementalData.QuarterlyOperatingCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.QuarterlySystemOperatingCounts != null)
-                                LoadSupplementalDataUpdateDataRow("SYSOP", suppDateCd, supplementalData.QuarterlySystemOperatingCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("SYSOP", suppDateCd, supplementalData.QuarterlySystemOperatingCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.QuarterlyComponentOperatingCounts != null)
-                                LoadSupplementalDataUpdateDataRow("CMPOP", suppDateCd, supplementalData.QuarterlyComponentOperatingCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("CMPOP", suppDateCd, supplementalData.QuarterlyComponentOperatingCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.QuarterlySystemQualityAssuredCounts != null)
-                                LoadSupplementalDataUpdateDataRow("SYSQA", suppDateCd, supplementalData.QuarterlySystemQualityAssuredCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("SYSQA", suppDateCd, supplementalData.QuarterlySystemQualityAssuredCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.QuarterlyComponentQualityAssuredCounts != null)
-                                LoadSupplementalDataUpdateDataRow("CMPQA", suppDateCd, supplementalData.QuarterlyComponentQualityAssuredCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("CMPQA", suppDateCd, supplementalData.QuarterlyComponentQualityAssuredCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.MayAndJuneOperatingCounts != null)
-                                LoadSupplementalDataUpdateDataRow("OPMJ", suppDateCd, supplementalData.MayAndJuneOperatingCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("OPMJ", suppDateCd, supplementalData.MayAndJuneOperatingCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.MayAndJuneSystemOperatingCounts != null)
-                                LoadSupplementalDataUpdateDataRow("SYSOPMJ", suppDateCd, supplementalData.MayAndJuneSystemOperatingCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("SYSOPMJ", suppDateCd, supplementalData.MayAndJuneSystemOperatingCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.MayAndJuneComponentOperatingCounts != null)
-                                LoadSupplementalDataUpdateDataRow("CMPOPMJ", suppDateCd, supplementalData.MayAndJuneComponentOperatingCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("CMPOPMJ", suppDateCd, supplementalData.MayAndJuneComponentOperatingCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.MayAndJuneSystemQualityAssuredCounts != null)
-                                LoadSupplementalDataUpdateDataRow("SYSQAMJ", suppDateCd, supplementalData.MayAndJuneSystemQualityAssuredCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("SYSQAMJ", suppDateCd, supplementalData.MayAndJuneSystemQualityAssuredCounts, checkSessionId, supplementalDataUpdateDataTable);
 
                             if (supplementalData.MayAndJuneComponentQualityAssuredCounts != null)
-                                LoadSupplementalDataUpdateDataRow("CMPQAMJ", suppDateCd, supplementalData.MayAndJuneComponentQualityAssuredCounts, checkSessionId);
+                                LoadSupplementalDataUpdateDataRow("CMPQAMJ", suppDateCd, supplementalData.MayAndJuneComponentQualityAssuredCounts, checkSessionId, supplementalDataUpdateDataTable);
                         }
                     }
                 }
@@ -379,9 +376,10 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <param name="suppDateCd">Indicates whether the counts for for QA Cert Event days or Conditional Data Begin hours.</param>
         /// <param name="supplementalDataGroup">The count, date and hour data from which to populate the row.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
-        private static void LoadSupplementalDataUpdateDataRow(string suppDataCd, string suppDateCd, QaCertificationSupplementalDataGroup supplementalDataGroup, string checkSessionId)
+        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
+        private static void LoadSupplementalDataUpdateDataRow(string suppDataCd, string suppDateCd, QaCertificationSupplementalDataGroup supplementalDataGroup, string checkSessionId, DataTable supplementalDataUpdateDataTable)
         {
-            DataRow dataRow = SupplementalDataUpdateDataTable.NewRow();
+            DataRow dataRow = supplementalDataUpdateDataTable.NewRow();
 
             dataRow["CHK_SESSION_ID"] = checkSessionId;
             dataRow["QA_CERT_EVENT_ID"] = supplementalDataGroup.QaCertEventId;
@@ -393,7 +391,7 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
             dataRow["MON_LOC_ID"] = supplementalDataGroup.MonLocId;
             dataRow["RPT_PERIOD_ID"] = supplementalDataGroup.RptPeriodId;
 
-            SupplementalDataUpdateDataTable.Rows.Add(dataRow);
+            supplementalDataUpdateDataTable.Rows.Add(dataRow);
         }
 
         #endregion

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/QaCertificationSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/QaCertificationSupplementalData.cs
@@ -305,17 +305,16 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// </summary>
         public static string SupplementalDataUpdateTablePath { get { return SupplementalDataUpdateSchemaName + "." + SupplementalDataUpdateTableName; } }
 
-
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
-        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
         /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
         /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
-        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, QaCertificationSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
+        /// <returns>The updated SupplementalDataUpdateDataTable.</returns>
+        public static DataTable LoadSupplementalDataUpdateDataTable(Dictionary<string, QaCertificationSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            DataTable supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
             if (supplementalDataUpdateDataTable != null)
             {
@@ -367,6 +366,8 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
                     }
                 }
             }
+
+            return supplementalDataUpdateDataTable;
         }
 
         /// <summary>

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/SamplingTrainEvalInformation.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/SamplingTrainEvalInformation.cs
@@ -134,12 +134,13 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// Exception will occur if the data table object is null or the columns do not exist
         /// in the table.
         /// </summary>
+        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
         /// <param name="checkSessionId">The id of the workspace session for the evaluations.</param>
-        public void LoadSupplementalDataUpdateRow(string checkSessionId)
+        public void LoadSupplementalDataUpdateRow(DataTable supplementalDataUpdateDataTable, string checkSessionId)
         {
-            if ((SupplementalDataUpdateDataTable != null) && !IsSupplementalData)
+            if ((supplementalDataUpdateDataTable != null) && !IsSupplementalData)
             {
-                DataRow dataRow = SupplementalDataUpdateDataTable.NewRow();
+                DataRow dataRow = supplementalDataUpdateDataTable.NewRow();
 
                 dataRow["CHK_SESSION_ID"] = checkSessionId;
                 dataRow["TRAP_TRAIN_ID"] = TrapTrainId;
@@ -148,7 +149,7 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
                 dataRow["GFM_TOTAL_COUNT"] = TotalGfmCount;
                 dataRow["GFM_NOT_AVAILABLE_COUNT"] = NotAvailablelGfmCount;
 
-                SupplementalDataUpdateDataTable.Rows.Add(dataRow);
+                supplementalDataUpdateDataTable.Rows.Add(dataRow);
             }
         }
 

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/SamplingTrainEvalInformation.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/SamplingTrainEvalInformation.cs
@@ -34,11 +34,6 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
 
 
         /// <summary>
-        /// Contains the update data table object for sampling trian supplemental data.
-        /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
-
-        /// <summary>
         /// Contains the name of the update catalog (database) for sampling trian supplemental data.
         /// </summary>
         public static string SupplementalDataUpdateCatalogName { get { return "camdecmpscalc"; } }

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/SystemOperatingSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/SystemOperatingSupplementalData.cs
@@ -40,11 +40,6 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         #region Static Properties and Methods
 
         /// <summary>
-        /// Contains the update data table object for supplemental data.
-        /// </summary>
-        public static DataTable SupplementalDataUpdateDataTable { get; set; }
-
-        /// <summary>
         /// Contains the name of the update schema for the supplemental data.
         /// </summary>
         public static string SupplementalDataUpdateSchemaName { get { return "camdecmpscalc"; } }
@@ -63,22 +58,21 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
+        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
         /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
         /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
-        public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, SystemOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
-
-        //  public static void LoadSupplementalDataUpdateDataTable(Dictionary<string, SystemOperatingSupplementalData>[] supplementalDataDictionaryArray, decimal workspaceSessionId, SqlConnection connection)
+        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, SystemOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            SupplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
-            if (SupplementalDataUpdateDataTable != null)
+            if (supplementalDataUpdateDataTable != null)
             {
                 foreach (Dictionary<string, SystemOperatingSupplementalData> supplementalDataDictionary in supplementalDataDictionaryArray)
                 {
                     foreach (OperatingSupplementalData supplementalData in supplementalDataDictionary.Values)
                     {
-                        LoadSupplementalDataUpdateDataDoRow(supplementalData, "MON_SYS_ID", SupplementalDataUpdateDataTable, checkSessionId);
+                        LoadSupplementalDataUpdateDataDoRow(supplementalData, "MON_SYS_ID", supplementalDataUpdateDataTable, checkSessionId);
                     }
                 }
             }

--- a/CheckEngine/CheckEngine/SpecialParameterClasses/SystemOperatingSupplementalData.cs
+++ b/CheckEngine/CheckEngine/SpecialParameterClasses/SystemOperatingSupplementalData.cs
@@ -58,13 +58,13 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
         /// <summary>
         /// Creates a new instance of SupplementalDataUpdateDataTable and populates it with data from the passed dictionary array.  
         /// </summary>
-        /// <param name="supplementalDataUpdateDataTable">The SupplementalDataUpdateDataTable to udpate.</param>
         /// <param name="supplementalDataDictionaryArray">Dictionary containing data used to update the table.</param>
         /// <param name="checkSessionId">The workspace session id for check session.</param>
         /// <param name="connection">Database connection to use when creating the internal supplemental data table.</param>
-        public static void LoadSupplementalDataUpdateDataTable(DataTable supplementalDataUpdateDataTable, Dictionary<string, SystemOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
+        /// <returns>The updated SupplementalDataUpdateDataTable.</returns>
+        public static DataTable LoadSupplementalDataUpdateDataTable(Dictionary<string, SystemOperatingSupplementalData>[] supplementalDataDictionaryArray, string checkSessionId, NpgsqlConnection connection)
         {
-            supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
+            DataTable supplementalDataUpdateDataTable = cDataFunctions.CreateDataTable(SupplementalDataUpdateSchemaName, SupplementalDataUpdateTableName, connection);
 
             if (supplementalDataUpdateDataTable != null)
             {
@@ -76,6 +76,8 @@ namespace ECMPS.Checks.CheckEngine.SpecialParameterClasses
                     }
                 }
             }
+
+            return supplementalDataUpdateDataTable;
         }
         
         #endregion

--- a/CheckEngine/DM/Utilities/cCalculator.cs
+++ b/CheckEngine/DM/Utilities/cCalculator.cs
@@ -65,16 +65,6 @@ namespace ECMPS.DM.Utilities
     #endregion
 
 
-    #region Public Properties
-
-    /// <summary>
-    /// Unexpected exception trapped by calculator
-    /// </summary>
-    public static Exception TrappedException { get; private set; }
-
-    #endregion
-
-
     #region Public Methods: Evaluate
 
     /// <summary>

--- a/CheckEngine/DM/Utilities/cCalculator.cs
+++ b/CheckEngine/DM/Utilities/cCalculator.cs
@@ -68,11 +68,6 @@ namespace ECMPS.DM.Utilities
     #region Public Properties
 
     /// <summary>
-    /// Error detail
-    /// </summary>
-    public static string ErrorDetail { get; private set; }
-
-    /// <summary>
     /// Unexpected exception trapped by calculator
     /// </summary>
     public static Exception TrappedException { get; private set; }
@@ -95,7 +90,6 @@ namespace ECMPS.DM.Utilities
     {
       bool failed = false;
 
-      TrappedException = null;
       errorResult = null;
 
       Stack<decimal> stack = new Stack<decimal>();
@@ -120,7 +114,6 @@ namespace ECMPS.DM.Utilities
               }
               else
               {
-                ErrorDetail = equation.Substring(charPos);
                 errorResult = eCalculatorError.Index;
                 failed = true;
               }
@@ -137,7 +130,6 @@ namespace ECMPS.DM.Utilities
               }
               else
               {
-                ErrorDetail = equation.Substring(charPos);
                 errorResult = eCalculatorError.Value;
                 failed = true;
               }
@@ -198,7 +190,6 @@ namespace ECMPS.DM.Utilities
 
                     default:
                       {
-                        ErrorDetail = character.ToString();
                         errorResult = eCalculatorError.Operator;
                         failed = true;
                       }
@@ -207,14 +198,12 @@ namespace ECMPS.DM.Utilities
                 }
                 catch (Exception ex)
                 {
-                  TrappedException = ex;
                   errorResult = eCalculatorError.Exception;
                   failed = true;
                 }
               }
               else
               {
-                ErrorDetail = stack.Count.ToString();
                 errorResult = eCalculatorError.OperandCount;
                 failed = true;
               }
@@ -223,7 +212,6 @@ namespace ECMPS.DM.Utilities
 
           default:
             {
-              ErrorDetail = character.ToString();
               errorResult = eCalculatorError.UnexpectedCharacter;
               failed = true;
             }

--- a/CheckEngine/DM/Utilities/cCalculator.cs
+++ b/CheckEngine/DM/Utilities/cCalculator.cs
@@ -196,7 +196,7 @@ namespace ECMPS.DM.Utilities
                       break;
                   }
                 }
-                catch (Exception ex)
+                catch
                 {
                   errorResult = eCalculatorError.Exception;
                   failed = true;

--- a/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
+++ b/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
@@ -123,17 +123,6 @@ namespace ECMPS.Checks.DatabaseAccess
         /// </summary>
         private string m_sLastError = "";
 
-        static private bool _bStealth = false;
-
-        /// <summary>
-        /// Do we show errors, or are we being stealthy?
-        /// </summary>
-        public static bool StealthMode
-        {
-            get { return _bStealth; }
-            set { _bStealth = value; }
-        }
-
         /// <summary>
         /// The NpgsqlClient.Command object
         /// </summary>
@@ -540,8 +529,7 @@ namespace ECMPS.Checks.DatabaseAccess
                 // set our error flag!
                 m_bInternalError = true;
 
-                if (_bStealth == false)
-                    Logging.LogException(_LastException, "Error Connecting to Database");
+                Logging.LogException(_LastException, "Error Connecting to Database");
             }
 
             return bRetVal;
@@ -2546,94 +2534,6 @@ namespace ECMPS.Checks.DatabaseAccess
             }
 
             return nSessionID;
-        }
-
-        #endregion
-
-
-        #region Public Static Methods: Severity Code
-
-        private static DataView m_dvSeverityCode = null;
-
-        /// <summary>
-        /// Returns the Severity Description associated with the passed Severity Code.
-        /// </summary>
-        /// <param name="ASeverityCd">The severity code for which a discription is returned.</param>
-        /// <param name="ADefault">The default description to use if the passed severity code is not known.</param>
-        /// <returns>The description associated with the passed severity code.</returns>
-        [Obsolete("Please use new extension method on eSeverityCd", false)]
-        public static string GetSeverityDescription(string ASeverityCd, string ADefault)
-        {
-            string Result = ADefault;
-
-            if ((m_dvSeverityCode != null) || LoadSeverityCode())
-            {
-                DataRowView SeverityRow = GetSeverityRow(ASeverityCd);
-
-                if ((SeverityRow != null) && (SeverityRow["Severity_Cd_Description"] != DBNull.Value))
-                    Result = Convert.ToString(SeverityRow["Severity_Cd_Description"]);
-            }
-
-            return Result;
-        }
-
-        /// <summary>
-        /// Returns the Severity Description associated with the passed Severity Level.
-        /// </summary>
-        /// <param name="ASeverityCd">The severity code for which a level is returned.</param>
-        /// <param name="ADefault">The default level to use if the passed severity code is not known.</param>
-        /// <returns>The level associated with the passed severity code.</returns>
-        [Obsolete("Please use new extension method on eSeverityCd", false)]
-        public static int GetSeverityLevel(string ASeverityCd, int ADefault)
-        {
-            int Result = ADefault;
-
-            if ((m_dvSeverityCode != null) || LoadSeverityCode())
-            {
-                DataRowView SeverityRow = GetSeverityRow(ASeverityCd);
-
-                if ((SeverityRow != null) && (SeverityRow["Severity_Level"] != DBNull.Value))
-                    Result = Convert.ToInt32(SeverityRow["Severity_Level"]);
-            }
-
-            return Result;
-        }
-
-        private static DataRowView GetSeverityRow(string ASeverityCd)
-        {
-            DataRowView Result = null;
-
-            if (!string.IsNullOrEmpty(ASeverityCd))
-            {
-                m_dvSeverityCode.RowFilter = string.Format("Severity_Cd = '{0}'", ASeverityCd);
-
-                if (m_dvSeverityCode.Count == 1)
-                    Result = m_dvSeverityCode[0];
-
-                m_dvSeverityCode.RowFilter = null;
-            }
-
-            return Result;
-        }
-
-        private static bool LoadSeverityCode()
-        {
-            string sql = "select Severity_Cd, Severity_Cd_Description, Severity_Level from camdecmpsmd.severity_code";
-            // Using replica db: camdecmpsmd.severity_code is read-only reference data
-            cDatabase dbConnection = cDatabase.GetConnection("LoadSeverityCode", cDatabase.eDatabaseTarget.READONLY);
-
-            try
-            {
-                DataTable SverityCodeTable = dbConnection.GetDataTable(sql);
-                m_dvSeverityCode = new DataView(SverityCodeTable, null, "Severity_Cd", DataViewRowState.CurrentRows);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                m_dvSeverityCode = null;
-                LoggerProvider.GetLogger(typeof(cDatabase).FullName).LogError(ex, "Loading of SEVERITY_CODE view failed");
-                return false;
-            }
         }
 
         #endregion

--- a/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
+++ b/CheckEngine/DatabaseAccess/cNpgsqlServer.cs
@@ -157,8 +157,20 @@ namespace ECMPS.Checks.DatabaseAccess
         /// </summary>
         static public string DbConnectionString
         {
-            get { return _sDbConnectionString; }
-            set { _sDbConnectionString = value; }
+            get 
+            {
+                lock (_dataSourceLock)
+                {
+                    return _sDbConnectionString;
+                }
+            }
+            set
+            {
+                lock (_dataSourceLock)
+                {
+                    _sDbConnectionString = value; 
+                }
+            }
         }
 
         /// <summary>
@@ -500,13 +512,13 @@ namespace ECMPS.Checks.DatabaseAccess
                 {
                     _logger.LogWarning(ex, "Failed to create connection from data source, falling back to direct connection");
                     // Fallback to direct connection if data source fails
-                    m_sqlConn = new NpgsqlConnection(_sDbConnectionString);
+                    m_sqlConn = new NpgsqlConnection(DbConnectionString);
                 }
             }
             else
             {
                 // Fallback if data source initialization failed
-                m_sqlConn = new NpgsqlConnection(_sDbConnectionString);
+                m_sqlConn = new NpgsqlConnection(DbConnectionString);
             }
 
             try
@@ -517,7 +529,7 @@ namespace ECMPS.Checks.DatabaseAccess
             }
             catch (NpgsqlException sqlEx)
             {
-                string sError = string.Format("The action failed. Connection String: {0}", _sDbConnectionString);
+                string sError = string.Format("The action failed. Connection String: {0}", DbConnectionString);
 
                 _LastException = new Exception(sError, sqlEx);
                 _LastException.Source = "ECMPS.Client.Common.cNpgsqlDatabase.Open()";

--- a/CheckEngine/Emissions/EmissionReport/Checks/HourlyGeneralChecks.cs
+++ b/CheckEngine/Emissions/EmissionReport/Checks/HourlyGeneralChecks.cs
@@ -2527,8 +2527,6 @@ namespace ECMPS.Checks.EmissionsChecks
                     decimal minValue = (fFactorRangeChecksRow != null) ? fFactorRangeChecksRow.LowerValue.AsDecimal().Default(Decimal.MinValue) : Decimal.MinValue;
                     decimal maxValue = (fFactorRangeChecksRow != null) ? fFactorRangeChecksRow.UpperValue.AsDecimal().Default(Decimal.MaxValue) : Decimal.MaxValue;
 
-                    FcValidationInfo.NonFuelSpecificMinValue = minValue;
-                    FcValidationInfo.NonFuelSpecificMaxValue = maxValue;
 
                     for (int dex = 0; dex < emParams.FcValidationInfoByLocationArray.Length; dex++)
                         emParams.FcValidationInfoByLocationArray[dex] = new FcValidationInfo(minValue, maxValue);

--- a/CheckEngine/Emissions/EmissionReport/Checks/HourlyOperatingDataChecks.cs
+++ b/CheckEngine/Emissions/EmissionReport/Checks/HourlyOperatingDataChecks.cs
@@ -2229,7 +2229,7 @@ namespace ECMPS.Checks.EmissionsChecks
                                 decimal minValue = (fFactorRangeChecksRow != null) ? fFactorRangeChecksRow.LowerValue.AsDecimal().Default(Decimal.MinValue) : Decimal.MinValue;
                                 decimal maxValue = (fFactorRangeChecksRow != null) ? fFactorRangeChecksRow.UpperValue.AsDecimal().Default(Decimal.MaxValue) : Decimal.MaxValue;
 
-                                fcValidationInfo = new FcValidationInfo(FcValidationInfo.NonFuelSpecificMinValue.Value, FcValidationInfo.NonFuelSpecificMaxValue.Value);
+                                fcValidationInfo = new FcValidationInfo(minValue, maxValue);
                             }
 
 

--- a/CheckEngine/Emissions/EmissionReport/EmissionsReportProcess.cs
+++ b/CheckEngine/Emissions/EmissionReport/EmissionsReportProcess.cs
@@ -1030,6 +1030,46 @@ namespace ECMPS.Checks.EmissionsReport
         #endregion
 
 
+        #region Supplemental Data Table
+
+        /// <summary>
+        /// Contains the data table used to store ComponentOperatingSupplementalData data.
+        /// </summary>
+        public DataTable ComponentOperatingSupplementalDataTable { get; private set; }
+
+        /// <summary>
+        /// Contains the data table used to store location level cDailyCalibrationData data.
+        /// </summary>
+        public DataTable DailyCalibrationLocationSupplementalDataTable { get; private set; }
+
+        /// <summary>
+        /// Contains the data table used to store system level cDailyCalibrationData data.
+        /// </summary>
+        public DataTable DailyCalibrationSystemSupplementalDataTable { get; private set; }
+
+        /// <summary>
+        /// Contains the data table used to store LastQualityAssuredValueSupplementalData data.
+        /// </summary>
+        public DataTable LastQualityAssuredValueSupplementalDataTable { get; private set; }
+
+        /// <summary>
+        /// Contains the data table used to store QaCertificationSupplementalData data.
+        /// </summary>
+        public DataTable QaCertificationSupplementalDataTable { get; private set; }
+
+        /// <summary>
+        /// Contains the data table used to store SamplingTrainEvalInformation data.
+        /// </summary>
+        public DataTable SamplingTrainSupplementalDataTable { get; private set; }
+
+        /// <summary>
+        /// Contains the data table used to store SystemOperatingSupplementalData data.
+        /// </summary>
+        public DataTable SystemOperatingSupplementalDataTable { get; private set; }
+
+        #endregion
+
+
         #region Base Class Overrides: ExecuteChecksWork with Support Methods
 
         protected override string ExecuteChecksWork()
@@ -1277,11 +1317,11 @@ namespace ECMPS.Checks.EmissionsReport
                 // Populate Supplemental Data Tables for Database Updating
                 SaveOperatingSuppFuelData(RptPeriodId, MonitorLocationView);
                 SamplingTrainSuppDataUpdate();
-                QaCertificationSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.QaCertEventSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                SystemOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.SystemOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                ComponentOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.ComponentOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                LastQualityAssuredValueSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.LastQualityAssuredValueSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                emParams.MostRecentDailyCalibrationTestObject.LoadIntoSupplementalDataTables(CheckEngine.RptPeriodId.Value, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                QaCertificationSupplementalData.LoadSupplementalDataUpdateDataTable(QaCertificationSupplementalDataTable, emParams.QaCertEventSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                SystemOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(SystemOperatingSupplementalDataTable, emParams.SystemOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                ComponentOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(ComponentOperatingSupplementalDataTable, emParams.ComponentOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                LastQualityAssuredValueSupplementalData.LoadSupplementalDataUpdateDataTable(LastQualityAssuredValueSupplementalDataTable, emParams.LastQualityAssuredValueSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                emParams.MostRecentDailyCalibrationTestObject.LoadIntoSupplementalDataTables(DailyCalibrationLocationSupplementalDataTable, DailyCalibrationSystemSupplementalDataTable, CheckEngine.RptPeriodId.Value, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
 
                 FSummaryValueInitializationCategory.EraseParameters();
 
@@ -4613,30 +4653,7 @@ namespace ECMPS.Checks.EmissionsReport
         /// <returns>Returns true if the update succeeds.</returns>
         protected override bool DbUpdate_CalcWsLoad(NpgsqlTransaction sqlTransaction, ref string errorMessage)
         {            
-            DataTable[] sourceTables = new DataTable[]
-            {FCalcDailyCal, FCalcDailyTestSummary, FCalcDerivedHrlyValue, FCalcMonitorHrlyValue, FCalcHrlyFuelFlow, FCalcHrlyParamFuelFlow, FCalcLongTermFuelFlow, FCalcDailyEmission, FCalcDailyFuel, FCalcSummaryValue, CalcMATSDHVData, CalcMATSMHVData,
-            CalcHrlyGasFlowMeter, CalcSamplingTrain, CalcSorbentTrap, SamplingTrainEvalInformation.SupplementalDataUpdateDataTable, CalcWeeklyTestSummary, CalcWeeklySystemIntegrity, QaCertificationSupplementalData.SupplementalDataUpdateDataTable,
-            SystemOperatingSupplementalData.SupplementalDataUpdateDataTable, ComponentOperatingSupplementalData.SupplementalDataUpdateDataTable, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateDataTable,
-            cDailyCalibrationData.SupplementalDataUpdateLocationDataTable, cDailyCalibrationData.SupplementalDataUpdateSystemDataTable};
-            
-            string[] tableLocation = new string[]{"camdecmpscalc.daily_calibration", "camdecmpscalc.daily_test_summary", "camdecmpscalc.derived_hrly_value", "camdecmpscalc.monitor_hrly_value", "camdecmpscalc.hrly_param_fuel_flow", "camdecmpscalc.long_term_fuel_flow",
-            "camdecmpscalc.daily_emission", "camdecmpscalc.daily_fuel", "camdecmpscalc.summary_value", "camdecmpscalc.mats_derived_hrly_value", "camdecmpscalc.mats_monitor_hrly_value", "camdecmpscalc.hrly_gas_flow_meter", "camdecmpscalc.sampling_train","camdecmpscalc.sorbent_trap",
-            SamplingTrainEvalInformation.SupplementalDataUpdateTableName, "camdecmpscalc.weekly_test_summary", "camdecmpscalc.weekly_system_integrity", QaCertificationSupplementalData.SupplementalDataUpdateTablePath, SystemOperatingSupplementalData.SupplementalDataUpdateTablePath,
-            ComponentOperatingSupplementalData.SupplementalDataUpdateTablePath, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateTablePath, cDailyCalibrationData.SupplementalDataUpdateLocationTablePath, cDailyCalibrationData.SupplementalDataUpdateSystemTablePath};
-
-            
             bool result;
-            /*
-            for(int i = 0; i < sourceTables.Length; i++){
-                Task.Run(() => 
-                {
-                    result = DbConnection.BulkLoad(sourceTables[i], tableLocation[i], ref errorMessage);    
-                } );
-            }
-            */
-
-            //if (mCheckEngine.DbConnection.ClearUpdateSession(eWorkspaceDataType.EM, mCheckEngine.ChkSessionId))
-            //{
             if (
                         DbConnection.BulkLoad(FCalcDailyCal, "camdecmpscalc.daily_calibration", ref errorMessage) &&
                         DbConnection.BulkLoad(FCalcDailyTestSummary, "camdecmpscalc.daily_test_summary", ref errorMessage) &&
@@ -4658,30 +4675,22 @@ namespace ECMPS.Checks.EmissionsReport
                         DbConnection.BulkLoad(CalcSamplingTrain, "camdecmpscalc.sampling_train", ref errorMessage) &&
                         DbConnection.BulkLoad(CalcSorbentTrap, "camdecmpscalc.sorbent_trap", ref errorMessage) &&
                         /* Sampling Train Supplemental Data*/
-                        DbConnection.BulkLoad(SamplingTrainEvalInformation.SupplementalDataUpdateDataTable,
-                                                SamplingTrainEvalInformation.SupplementalDataUpdateTablePath,
-                                                ref errorMessage) &&
                         /* Weekly Emission Tests */
                         DbConnection.BulkLoad(CalcWeeklyTestSummary, "camdecmpscalc.weekly_test_summary", ref errorMessage) &&
                         DbConnection.BulkLoad(CalcWeeklySystemIntegrity, "camdecmpscalc.weekly_system_integrity", ref errorMessage) &&
                         /* Supplemental Data*/
-                        DbConnection.BulkLoad(QaCertificationSupplementalData.SupplementalDataUpdateDataTable, QaCertificationSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(SystemOperatingSupplementalData.SupplementalDataUpdateDataTable, SystemOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(ComponentOperatingSupplementalData.SupplementalDataUpdateDataTable, ComponentOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(LastQualityAssuredValueSupplementalData.SupplementalDataUpdateDataTable, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(cDailyCalibrationData.SupplementalDataUpdateLocationDataTable, cDailyCalibrationData.SupplementalDataUpdateLocationTablePath, ref errorMessage) &&
-                        DbConnection.BulkLoad(cDailyCalibrationData.SupplementalDataUpdateSystemDataTable, cDailyCalibrationData.SupplementalDataUpdateSystemTablePath, ref errorMessage) &&
+                        DbConnection.BulkLoad(SamplingTrainSupplementalDataTable, SamplingTrainEvalInformation.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                        DbConnection.BulkLoad(QaCertificationSupplementalDataTable, QaCertificationSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                        DbConnection.BulkLoad(SystemOperatingSupplementalDataTable, SystemOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                        DbConnection.BulkLoad(ComponentOperatingSupplementalDataTable, ComponentOperatingSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                        DbConnection.BulkLoad(LastQualityAssuredValueSupplementalDataTable, LastQualityAssuredValueSupplementalData.SupplementalDataUpdateTablePath, ref errorMessage) &&
+                        DbConnection.BulkLoad(DailyCalibrationLocationSupplementalDataTable, cDailyCalibrationData.SupplementalDataUpdateLocationTablePath, ref errorMessage) &&
+                        DbConnection.BulkLoad(DailyCalibrationSystemSupplementalDataTable, cDailyCalibrationData.SupplementalDataUpdateSystemTablePath, ref errorMessage) &&
                         cLastDailyInterferenceCheck.SaveSupplementalData(LatesDailyInterferenceCheckObject, CheckEngine.RptPeriodId.Value, CheckEngine.ChkSessionId, DbConnection, ref errorMessage)
                    )
                     result = true;
                 else
                     result = false;
-            //}
-            //else
-            //{
-                //errorMessage = mCheckEngine.DbWsConnection.LastError;
-                //result = false;
-            //}
 
             return result;
         }
@@ -6024,7 +6033,7 @@ namespace ECMPS.Checks.EmissionsReport
 
             foreach (SamplingTrainEvalInformation samplingTrainEvalInformation in emParams.MatsSamplingTrainDictionary.Values)
             {
-                samplingTrainEvalInformation.LoadSupplementalDataUpdateRow(CheckEngine.ChkSessionId);
+                samplingTrainEvalInformation.LoadSupplementalDataUpdateRow(SamplingTrainSupplementalDataTable, CheckEngine.ChkSessionId);
             }
         }
 

--- a/CheckEngine/Emissions/EmissionReport/EmissionsReportProcess.cs
+++ b/CheckEngine/Emissions/EmissionReport/EmissionsReportProcess.cs
@@ -1314,14 +1314,22 @@ namespace ECMPS.Checks.EmissionsReport
 
                 } // Abort Checks check
 
+                // Initialize Daily Calibration Supplemental Data Table variables
+                DataTable dailyCalibrationLocationSupplementalDataTable;
+                DataTable dailyCalibrationSystemSupplementalDataTable;
+
                 // Populate Supplemental Data Tables for Database Updating
                 SaveOperatingSuppFuelData(RptPeriodId, MonitorLocationView);
                 SamplingTrainSuppDataUpdate();
-                QaCertificationSupplementalData.LoadSupplementalDataUpdateDataTable(QaCertificationSupplementalDataTable, emParams.QaCertEventSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                SystemOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(SystemOperatingSupplementalDataTable, emParams.SystemOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                ComponentOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(ComponentOperatingSupplementalDataTable, emParams.ComponentOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                LastQualityAssuredValueSupplementalData.LoadSupplementalDataUpdateDataTable(LastQualityAssuredValueSupplementalDataTable, emParams.LastQualityAssuredValueSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
-                emParams.MostRecentDailyCalibrationTestObject.LoadIntoSupplementalDataTables(DailyCalibrationLocationSupplementalDataTable, DailyCalibrationSystemSupplementalDataTable, CheckEngine.RptPeriodId.Value, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                QaCertificationSupplementalDataTable = QaCertificationSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.QaCertEventSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                SystemOperatingSupplementalDataTable = SystemOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.SystemOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                ComponentOperatingSupplementalDataTable = ComponentOperatingSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.ComponentOperatingSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                LastQualityAssuredValueSupplementalDataTable = LastQualityAssuredValueSupplementalData.LoadSupplementalDataUpdateDataTable(emParams.LastQualityAssuredValueSuppDataDictionaryArray, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+                emParams.MostRecentDailyCalibrationTestObject.LoadIntoSupplementalDataTables(out dailyCalibrationLocationSupplementalDataTable, out dailyCalibrationSystemSupplementalDataTable, CheckEngine.RptPeriodId.Value, CheckEngine.ChkSessionId, CheckEngine.DbConnection.SQLConnection);
+
+                // Update the Daily Calibration Supplemental Data Table properties
+                DailyCalibrationLocationSupplementalDataTable = dailyCalibrationLocationSupplementalDataTable;
+                DailyCalibrationSystemSupplementalDataTable = dailyCalibrationSystemSupplementalDataTable;
 
                 FSummaryValueInitializationCategory.EraseParameters();
 
@@ -6025,7 +6033,7 @@ namespace ECMPS.Checks.EmissionsReport
         {
             string errorMessage = "";
 
-            SamplingTrainEvalInformation.SupplementalDataUpdateDataTable
+            SamplingTrainSupplementalDataTable
                 = CloneTable(SamplingTrainEvalInformation.SupplementalDataUpdateCatalogName,
                              SamplingTrainEvalInformation.SupplementalDataUpdateTableName,
                              CheckEngine.DbConnection.SQLConnection,

--- a/CheckEngine/MonitorPlan/Checks/FormulaChecks.cs
+++ b/CheckEngine/MonitorPlan/Checks/FormulaChecks.cs
@@ -1491,7 +1491,7 @@ namespace ECMPS.Checks.FormulaChecks
                     foreach (VwMonitorSystemRow monitorSystemRow in monitorSystemRecords)
                     {
                         if ((monitorSystemRow.BeginDatehour <= distinctHourRange.Began) && 
-                            (monitorSystemRow.EndDatehour.Default(DistinctHourRanges.MaxHour) >= distinctHourRange.Ended))
+                            (monitorSystemRow.EndDatehour.Default(distinctHourRanges.MaxHour) >= distinctHourRange.Ended))
                         {
                             monSysIdCondition = new cFilterCondition("MON_SYS_ID", monitorSystemRow.MonSysId);
                             monitorSystemComponentRecords
@@ -1502,7 +1502,7 @@ namespace ECMPS.Checks.FormulaChecks
                             {
                                 if ((monitorSystemComponentRow.MonSysId == monitorSystemRow.MonSysId) &&
                                     (monitorSystemComponentRow.BeginDatehour <= distinctHourRange.Began) &&
-                                    (monitorSystemComponentRow.EndDatehour.Default(DistinctHourRanges.MaxHour) >= distinctHourRange.Ended))
+                                    (monitorSystemComponentRow.EndDatehour.Default(distinctHourRanges.MaxHour) >= distinctHourRange.Ended))
                                 {
                                     componentCount += 1;
 

--- a/CheckEngine/TypeUtilities/DateFunctions.cs
+++ b/CheckEngine/TypeUtilities/DateFunctions.cs
@@ -23,38 +23,33 @@ namespace ECMPS.Checks.TypeUtilities
         {
         }
 
-        private static DataTable FReportingPeriodTable = null;
+
+        /// <summary>
+        /// Populates the Reporting Period table.
+        /// </summary>
+        static cDateFunctions()
+        {
+            try
+            {
+                // Using replica db: camdecmpsmd.reporting_period is read-only reference data
+                cDatabase Database = cDatabase.GetConnection("cDateFunctions", cDatabase.eDatabaseTarget.READONLY);
+
+                FReportingPeriodTable = Database.GetDataTable("select * from camdecmpsmd.reporting_period order by Calendar_Year, Quarter");
+            }
+            catch
+            {
+                FReportingPeriodTable = null;
+            }
+        }
+
+
+        private static readonly DataTable FReportingPeriodTable;
+
 
         /// <summary>
         /// Returns the current Reporting Period Table
         /// </summary>
-        public static DataTable ReportingPeriodTable
-        {
-            get
-            {
-                if (FReportingPeriodTable == null)
-                {
-                    try
-                    {
-                        // Using replica db: camdecmpsmd.reporting_period is read-only reference data
-                        cDatabase Database = cDatabase.GetConnection("cDateFunctions", cDatabase.eDatabaseTarget.READONLY);
-
-                        FReportingPeriodTable = Database.GetDataTable("select * from camdecmpsmd.reporting_period order by Calendar_Year, Quarter");
-                    }
-                    catch
-                    {
-                        FReportingPeriodTable = null;
-                    }
-                }
-
-                return FReportingPeriodTable;
-            }
-
-            set
-            {
-                FReportingPeriodTable = value;
-            }
-        }
+        public static DataTable ReportingPeriodTable { get { return FReportingPeriodTable; } }
 
 
         /// <summary>

--- a/CheckEngine/TypeUtilities/DecimalPrecision.cs
+++ b/CheckEngine/TypeUtilities/DecimalPrecision.cs
@@ -55,12 +55,12 @@ namespace ECMPS.Checks.TypeUtilities
 
     }
 
-    private static cHandleDecimalPrecision[] FDecimalPrecision;
+    private static readonly cHandleDecimalPrecision[] FDecimalPrecision;
 
     /// <summary>
-    /// Initialize the class
+    /// Initialize the FDecimalPrecision field.
     /// </summary>
-    public static void Initialize()
+    static cDecimalPrecision()
     {
       FDecimalPrecision = new cHandleDecimalPrecision[Enum.GetValues(typeof(eDecimalPrecision)).Length];
 

--- a/CheckEngine/TypeUtilities/DistinctHourRanges.cs
+++ b/CheckEngine/TypeUtilities/DistinctHourRanges.cs
@@ -58,13 +58,13 @@ namespace ECMPS.Checks.TypeUtilities
         /// <summary>
         /// The maximum hour with date for Distinct Hour Ranges.
         /// </summary>
-        public static DateTime MaxHour { get; private set; }
+        public DateTime MaxHour { get; private set; }
 
 
         /// <summary>
         /// The minimum hour with date for Distinct Hour Ranges.
         /// </summary>
-        public static DateTime MinHour { get; private set; }
+        public DateTime MinHour { get; private set; }
 
 
         /// <summary>

--- a/CheckEngine/TypeUtilities/Quarter.cs
+++ b/CheckEngine/TypeUtilities/Quarter.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Runtime.Serialization;
 
 namespace ECMPS.Checks.TypeUtilities
@@ -21,8 +23,6 @@ namespace ECMPS.Checks.TypeUtilities
 		/// <exception cref="System.ArgumentOutOfRangeException">Thrown when quarterKey represents a quarter before year 1 AD, quarter 1.</exception>
 		private Quarter(int quarterKey)
 		{
-			if (QuarterDictionary.ContainsKey(quarterKey))
-				throw new ArgumentException( $"A Quarter object was previously created for quarterKey {quarterKey}.", "quarterKey");
 			if (quarterKey < 5)
 				throw new ArgumentOutOfRangeException("quarterKey", quarterKey, "quarterKey must be greater than or equal to 5 to represent the minimum of year 1 AD, quarter 1.");
 
@@ -31,22 +31,46 @@ namespace ECMPS.Checks.TypeUtilities
 			
 			YearValue = GetYearValue(quarterKey);
 			QuarterValue = GetQuarterValue(quarterKey);
-
-			QuarterDictionary.Add(quarterKey, this);
 		}
 
 		#endregion
 
 
-		#region Public Static Methods: Get Quarter Object
+		#region Static Constructor
 
 		/// <summary>
-		/// Returns the Quarter object for the passed date, creating it if it does not already exist.
+		/// Static constructor that should run once for the class regardless of thread.
 		/// </summary>
-		/// <param name="quarterKey"></param>
-		/// <returns>The quarter object for the quarterKey.</returns>
-		/// <exception cref="System.ArgumentOutOfRangeException">Thrown when quarterKey represents a quarter before year 1 AD, quarter 1.</exception>
-		public static Quarter FetchQuarter(int quarterKey)
+		static Quarter()
+		{
+			int beginYear = 1993;
+			int endYear = DateTime.Now.Year + 1;
+            int quarterKey;
+
+			Dictionary<int, Quarter> quarterDictionary = new Dictionary<int, Quarter>();
+
+            for (int year = beginYear; year <= endYear; year++)
+                for (int quarter = 1; quarter <= 4; quarter++)
+                {
+                    quarterKey = GetQuarterKey(year, quarter);
+                    quarterDictionary.Add(quarterKey, new Quarter(quarterKey));
+                }
+
+			FrozenDictionary<int, Quarter> QuarterDictionary = quarterDictionary.ToFrozenDictionary();
+        }
+
+        #endregion
+
+
+        #region Public Static Methods: Get Quarter Object
+
+        /// <summary>
+        /// Returns the Quarter object for the passed date, creating it if it does not already exist.
+        /// </summary>
+        /// <param name="quarterKey"></param>
+        /// <returns>The quarter object for the quarterKey.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when quarterKey represents a quarter before year 1 AD, quarter 1.</exception>
+        public static Quarter FetchQuarter(int quarterKey)
 		{
 			if (quarterKey < 5)
 			{
@@ -54,9 +78,9 @@ namespace ECMPS.Checks.TypeUtilities
 			}
 
 			if (!QuarterDictionary.ContainsKey(quarterKey))
-			{
-				new Quarter(quarterKey); // Automatically added to QuarterDictionary
-			}
+            {
+                throw new ArgumentOutOfRangeException("quarterKey", quarterKey, $"quarterKey must be inclusively between years 1993 and {DateTime.Now.Year + 1}.");
+            }
 
 			return QuarterDictionary[quarterKey];
 		}
@@ -107,7 +131,7 @@ namespace ECMPS.Checks.TypeUtilities
 
         #region Private Statuc Fields
 
-        private static Dictionary<int, Quarter> QuarterDictionary = new Dictionary<int, Quarter>();
+        private static readonly FrozenDictionary<int, Quarter> QuarterDictionary;
 
 		#endregion
 

--- a/CheckEngine/TypeUtilities/Quarter.cs
+++ b/CheckEngine/TypeUtilities/Quarter.cs
@@ -56,7 +56,7 @@ namespace ECMPS.Checks.TypeUtilities
                     quarterDictionary.Add(quarterKey, new Quarter(quarterKey));
                 }
 
-			FrozenDictionary<int, Quarter> QuarterDictionary = quarterDictionary.ToFrozenDictionary();
+			QuarterDictionary = quarterDictionary.ToFrozenDictionary();
         }
 
         #endregion

--- a/CheckEngine/TypeUtilities/ReportingPeriod.cs
+++ b/CheckEngine/TypeUtilities/ReportingPeriod.cs
@@ -303,44 +303,30 @@ namespace ECMPS.Checks.TypeUtilities
     /// <summary>
     /// Returns the current Reporting Period Table
     /// </summary>
-    public static DataTable LookupTable
+    public static DataTable LookupTable { get { return FLookupTable; } }
+
+
+    static cReportingPeriod()
     {
-      get
-      {
-        if (FLookupTable == null)
+        try
         {
-          try
-          {
             // Using replica db: camdecmpsmd.reporting_period is read-only reference data
             cDatabase Database = cDatabase.GetConnection("cDateFunctions", cDatabase.eDatabaseTarget.READONLY);
 
             FLookupTable = Database.GetDataTable("select * from camdecmpsmd.reporting_period order by Calendar_Year, Quarter");
-          }
-          catch (Exception ex)
-          {
+        }
+        catch (Exception ex)
+        {
             LoggerProvider.GetLogger<cReportingPeriod>().LogError(ex, "Error retrieving Reporting Period Lookup Table");
             FLookupTable = null;
-          }
         }
-
-        return FLookupTable;
-      }
-
-      set
-      {
-        FLookupTable = value;
-      }
     }
 
 
-    #region Property Fields
-
-    /// <summary>
-    /// Contains the lookup table used to read reporting period information.
-    /// </summary>
-    protected static DataTable FLookupTable = null;
-
-    #endregion
+        /// <summary>
+        /// Contains the lookup table used to read reporting period information.
+        /// </summary>
+        protected static readonly DataTable FLookupTable = null;
 
     #endregion
 


### PR DESCRIPTION
## Replaced supplemental data table static properties.
1. Replaced the static properties in the various supplemental data classes with non-static properties in the emission process class.
2. Removed unused variable containing the static properties, an associated unused variable, and related commented out code.

- CheckEngine / SpecialParameterClasses
  - ComponentOperatingSupplementalData.cs
  - DailyCalibrationData.cs
  - LastQualityAssuredValueSupplementalData.cs
  - QaCertificationSupplementalData.cs
  - SamplingTrainEvalInformation.cs
  - SystemOperatingSupplementalData.cs
- Emissions / EmissionReport
  - EmissionReportProcess

## Removed static properties from FcValidationInfo class.
1. Updated HOURGEN-33 to remove setting of the static properties.
2. Updated HOURop-34 to replace use of the static properties with the existing minValue and maxValue variables.

- CheckEngine / SpecialParameterClasses
  - FcValidationInfo
- Emissions / EmissionReport / Checks
  - HourlyGeneralChecks.cs
  - HourlyOperatingDataChecks.cs
  - ReportingPeriod.cs

##  Changed Private Static Fields to Private Static Readonly Fields
- TypeUtilities
  - DistinctHourRanges.cs: Collateral changes in FormulaChecks.cs (MonitorPlan / Checks).
  - DateFunctions.cs: Collateral changes in CheckEngine.cs (CheckEngine)
  - DecimalPrecision.cs
  - Quarter.cs: Includes replacing incidental updates to QuarterDictionary with initial population.

## Remove the following static fields and associated properties and methods.
- DM / Utilities / cCalculator
  - ErrorDetail and TrappedException static properties
- DatabaseAccess / NpgsqlServer.cs / cDatabase
  - `private static DataView m_dvSeverityCode`
    - `public static string GetSeverityDescription(string ASeverityCd, string ADefault)`
    - 'public static int GetSeverityLevel(string ASeverityCd, int ADefault)'
    - 'private static DataRowView GetSeverityRow(string ASeverityCd)'
    - 'private static bool LoadSeverityCode()'
  - `static private bool _bStealth = false;`
    - `public static bool StealthMode { get { return _bStealth; } set { _bStealth = value; } }`
    - `if (_bStealth == false)` in `public bool Open()` but leaving the `Logging.LogException(_LastException, "Error Connecting to Database");`.

## Handled _sDbConnectionString static field
- DatabaseAccess / NpgsqlServer.cs / cDatabase
  1. Included locks in DbConnectionString getter and setter to place access to _sDbConnectionString in locks.
  2. Replaced references to _sDbConnectionString that are not with a lock with the DbConnectionString property.