### PR TITLE
Feature/6926 duplicate submission processing

### DIFF
--- a/admin/Jobs/EvaluationJobQueue.cs
+++ b/admin/Jobs/EvaluationJobQueue.cs
@@ -42,42 +42,32 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
             foreach(string processType in processTypes){
                 _logger.LogInformation("Checking {Type} evaluations", processType);
                 
-                List<Evaluation> inQueue = _dbContext.Evaluations.FromSqlRaw(@"
-                    SELECT *
-                    FROM camdecmpsaux.evaluation_queue
-                    WHERE process_cd = {0} AND status_cd = 'QUEUED'
-                    ORDER BY queued_time", processType
-                ).ToList();
+                int inQueueCount = _dbContext.Evaluations.Count(s => s.ProcessCode == processType && s.StatusCode == "QUEUED");
 
                 _logger.LogInformation("Found {Count} {Type} evaluations in QUEUED status", 
-                    inQueue.Count, processType);
+                    inQueueCount, processType);
 
                 // Exit if nothing in queue
-                if (inQueue.Count == 0) continue;
+                if (inQueueCount == 0) continue;
 
-                List<Evaluation> wipOrClaimed = _dbContext.Evaluations.FromSqlRaw(@"
-                    SELECT *
-                    FROM camdecmpsaux.evaluation_queue
-                    WHERE process_cd = {0} AND status_cd in ('WIP', 'CLAIMED')
-                    ORDER BY queued_time", processType
-                ).ToList();
+                int wipOrClaimedCount = _dbContext.Evaluations.Count(s => s.ProcessCode == processType && (s.StatusCode == "WIP" || s.StatusCode == "CLAIMED"));
 
                 _logger.LogInformation("Found {Count} {Type} evaluations in WIP or CLAIMED status", 
-                    wipOrClaimed.Count, processType);
+                    wipOrClaimedCount, processType);
 
                 int maxAllowed = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_" + processType +"_EVALUATIONS"]);
                 _logger.LogInformation("Max allowed {Type} evaluations: {MaxAllowed}", 
                     processType, maxAllowed);
 
                 // Exit if at max
-                if(wipOrClaimed.Count >= maxAllowed)
+                if(wipOrClaimedCount >= maxAllowed)
                 {
                   _logger.LogInformation("Maximum number of {Type} evaluations ({MaxAllowed}) already in progress", 
                       processType, maxAllowed);
                   continue;
                 }
 
-                int jobs_to_schedule = maxAllowed - wipOrClaimed.Count;
+                int jobs_to_schedule = maxAllowed - wipOrClaimedCount;
                 _logger.LogInformation("Attempting to schedule {JobCount} {Type} evaluations", 
                     jobs_to_schedule, processType);
 

--- a/admin/Jobs/SubmissionJobQueue.cs
+++ b/admin/Jobs/SubmissionJobQueue.cs
@@ -46,57 +46,67 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
             WHERE status_cd = 'QUEUED'"
           ).ToList();
 
-        List<SubmissionSet> inWIP = _dbContext.SubmissionSet.FromSqlRaw(@"
+        if (inQueue.Count == 0)
+        {
+          _logger.LogInformation("No items in queue to process.");
+          return;
+        }
+
+        List<SubmissionSet> wipOrClaimed = _dbContext.SubmissionSet.FromSqlRaw(@"
             SELECT *
             FROM camdecmpsaux.submission_set
-            WHERE status_cd = 'WIP'"
+            WHERE status_cd in ('WIP', 'CLAIMED')"
           ).ToList();
 
-        _logger.LogInformation("Found {InQueueCount} items in queue and {InWIPCount} items in WIP", inQueue?.Count ?? 0, inWIP?.Count ?? 0);
+        _logger.LogInformation("Found {InQueueCount} items in queue and {InWIPCount} items in WIP or CLAIMED", inQueue?.Count ?? 0, wipOrClaimed?.Count ?? 0);
 
-        if(inWIP.Count < Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_SUBMISSION_JOBS"])){
-          if(inQueue.Count > 0){
-            int jobs_to_schedule = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_SUBMISSION_JOBS"]) - inWIP.Count;
-            _logger.LogInformation("Scheduling {JobsToSchedule} jobs", jobs_to_schedule);
+        var maxAllowed = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_SUBMISSION_JOBS"]);
 
-            int index = 0;
-
-            string clientToken = await Utils.generateClientToken();
-
-            for(int i = 0; i < jobs_to_schedule; i++){
-              if(index < inQueue.Count){
-                var setRecord = inQueue[i];
-                setRecord.StatusCode = "WIP";
-                _dbContext.SubmissionSet.Update(setRecord);
-                _dbContext.SaveChanges();
-
-                _logger.LogInformation("Submitting to camd-services SubmissionSetId {SubmissionSetId}", setRecord.SetId);
-
-                try
-                {
-                  await SubmitSet(setRecord.SetId, clientToken);
-                }
-                catch (Exception ex)
-                {
-                  HandleSubmissionError(setRecord, ex);
-                }
-
-                Thread.Sleep(Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_SUBMISSION_JOB_QUEUE_DELAY"] ?? "1") * 1000);
-                index++;
-              }
-            }
-          }
-          else
-          {
-             _logger.LogInformation("No items in queue to process.");
-          }
+        // Exit if max number of allowed jobs already in progress
+        if (wipOrClaimed.Count >= maxAllowed) {
+            _logger.LogInformation("Maximum number of submission jobs ({MaxJobs}) already in progress. Skipping processing...", maxAllowed);
+            return;
         }
-        else
+
+        int jobs_to_schedule = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_SUBMISSION_JOBS"]) - wipOrClaimed.Count;
+        _logger.LogInformation("Scheduling {JobsToSchedule} jobs", jobs_to_schedule);
+
+        // Set to CLAIMED
+        List<SubmissionSet> claimed = _dbContext.SubmissionSet
+          .FromSqlRaw(@"
+              UPDATE camdecmpsaux.submission_set
+              SET status_cd = 'CLAIMED'
+              WHERE submission_set_id IN (
+                  SELECT submission_set_id
+                  FROM camdecmpsaux.submission_set
+                  WHERE status_cd = 'QUEUED'
+                  ORDER BY queued_time
+                  LIMIT {0}
+                  FOR UPDATE SKIP LOCKED
+              )
+              RETURNING *;",
+              jobs_to_schedule)
+          .ToList();
+
+        _logger.LogInformation("Claimed {ClaimedCount} submission sets for processing", claimed?.Count ?? 0);
+
+        string clientToken = await Utils.generateClientToken();
+
+        foreach (var setRecord in claimed)
         {
-           _logger.LogInformation("Maximum number of submission jobs ({MaxJobs}) already in progress. Skipping processing...", Configuration["EASEY_QUARTZ_SCHEDULER_MAX_SUBMISSION_JOBS"]);
-        }
+          _logger.LogInformation("Submitting to camd-services SubmissionSetId {SubmissionSetId}", setRecord.SetId);
 
-        return;
+          try
+          {
+            await SubmitSet(setRecord.SetId, clientToken);
+          }
+          catch (Exception ex)
+          {
+            HandleSubmissionError(setRecord, ex);
+          }
+
+          Thread.Sleep(Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_SUBMISSION_JOB_QUEUE_DELAY"] ?? "1") * 1000);
+        }
       }
       catch (Exception e)
       {

--- a/admin/Jobs/SubmissionJobQueue.cs
+++ b/admin/Jobs/SubmissionJobQueue.cs
@@ -40,35 +40,25 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
       {
         _logger.LogInformation("Starting submission job execution. Checking QUEUED status submissions ");
 
-        List<SubmissionSet> inQueue = _dbContext.SubmissionSet.FromSqlRaw(@"
-            SELECT *
-            FROM camdecmpsaux.submission_set
-            WHERE status_cd = 'QUEUED'"
-          ).ToList();
+        int inQueueCount = _dbContext.SubmissionSet.Count(s => s.StatusCode == "QUEUED");
 
-        if (inQueue.Count == 0)
-        {
-          _logger.LogInformation("No items in queue to process.");
-          return;
-        }
+        _logger.LogInformation("Found {InQueueCount} submission sets in QUEUED status", inQueueCount);
 
-        List<SubmissionSet> wipOrClaimed = _dbContext.SubmissionSet.FromSqlRaw(@"
-            SELECT *
-            FROM camdecmpsaux.submission_set
-            WHERE status_cd in ('WIP', 'CLAIMED')"
-          ).ToList();
+        if (inQueueCount == 0) return;
 
-        _logger.LogInformation("Found {InQueueCount} items in queue and {InWIPCount} items in WIP or CLAIMED", inQueue?.Count ?? 0, wipOrClaimed?.Count ?? 0);
+        int wipOrClaimedCount = _dbContext.SubmissionSet.Count(s => s.StatusCode == "WIP" || s.StatusCode == "CLAIMED");
+
+        _logger.LogInformation("Found {InQueueCount} items in queue and {InWIPCount} items in WIP or CLAIMED", inQueueCount, wipOrClaimedCount);
 
         var maxAllowed = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_SUBMISSION_JOBS"]);
 
         // Exit if max number of allowed jobs already in progress
-        if (wipOrClaimed.Count >= maxAllowed) {
+        if (wipOrClaimedCount >= maxAllowed) {
             _logger.LogInformation("Maximum number of submission jobs ({MaxJobs}) already in progress. Skipping processing...", maxAllowed);
             return;
         }
 
-        int jobs_to_schedule = Int32.Parse(Configuration["EASEY_QUARTZ_SCHEDULER_MAX_SUBMISSION_JOBS"]) - wipOrClaimed.Count;
+        int jobs_to_schedule = maxAllowed - wipOrClaimedCount;
         _logger.LogInformation("Scheduling {JobsToSchedule} jobs", jobs_to_schedule);
 
         // Set to CLAIMED


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6926

## Main Changes:

- Set submission sets to CLAIMED status rather than WIP. The camd-services submission processing job will set the status to WIP when it begins processing.