### PR TITLE
bump npgsql.entityframeworkcore.postgresql

### DIFF
--- a/CheckEngine/DatabaseAccess/DatabaseAccess.csproj
+++ b/CheckEngine/DatabaseAccess/DatabaseAccess.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/admin/easey-job-scheduler.csproj
+++ b/admin/easey-job-scheduler.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AWSSDK.S3" Version="3.7.511.5" />
     <PackageReference Include="DotNetEnv" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.9.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.9.0" />


### PR DESCRIPTION
Bump Npgsql.EntityFrameworkCore.PostgreSQL from 9.0.3 to 9.0.4

(was originally a Dependabot PR, but both projects need to be updated at the same time, which Dependabot was not able to figure out on its own)
