### PR TITLE
Fix- Duplicate feedback emails (RT 83565 & 83637) (#7159)

### DIFF
--- a/admin/Jobs/SubmissionJobQueue.cs
+++ b/admin/Jobs/SubmissionJobQueue.cs
@@ -128,7 +128,7 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
         submissionDateDisplay = setRecord.QueuedTime.ToString("MMMM dd, yyyy 'at' h:mm tt"),
         submissionId = setRecord.SetId,
         submitter = setRecord.UserId,
-        yearQtr = "N/A", // The error occurred before processing any individual submissions, so this is not applicable
+        yearQtr = "N/A",
       };
       return JsonConvert.SerializeObject(context);
     }
@@ -249,37 +249,55 @@ namespace Epa.Camd.Quartz.Scheduler.Jobs
                     Configuration["EASEY_CAMD_SERVICES"] + "/submission/process", 
                     httpContent);
 
-                response.EnsureSuccessStatusCode();
+          /// FIX: 202 Accepted is the expected success response from /submission/process.
+          /// Do NOT retry - submission is already processing asynchronously in background.
+          /// Retrying causes duplicate processSubmissionSet executions and duplicate
+          /// feedback emails (EM, MP, QA) sent to users.
+          if (response.StatusCode == System.Net.HttpStatusCode.Accepted)
+          {
+            _logger.LogInformation(
+              "Submission accepted for async processing (202). SubmissionSetId: {SubmissionSetId}",
+              setId);
+            return;
+          }
 
-                _logger.LogInformation(
-                    "Submitted job for SubmissionSetId {SubmissionSetId} with response {ResponseStatusCode}",
-                    setId, response.StatusCode);
+          /// Any other 2xx is also a success - do not retry
+          if (response.IsSuccessStatusCode)
+          {
+            _logger.LogInformation(
+              "Submitted job for SubmissionSetId {SubmissionSetId} with response {ResponseStatusCode}",
+              setId, response.StatusCode);
+            return;
+          }
 
-                return; // success, exit method
-            }
-            catch (Exception e) when (retryCount < maxRetries - 1)
-            {
-                // Calculate exponential backoff with jitter (e.g., 0.5x to 1.5x of the base delay)
-                int delayMs = (int)(Math.Pow(2, retryCount) * 1000);
-                int jitter = rng.Next((int)(delayMs * 0.5), (int)(delayMs * 1.5));
+          /// Non-success: log warning and throw to trigger retry logic
+          _logger.LogWarning(
+            "Non-success response for SubmissionSetId {SubmissionSetId}. Status: {StatusCode}. Will retry if attempts remain.",
+            setId, response.StatusCode);
 
-                _logger.LogWarning(
-                    e,
-                    "Error submitting SubmissionSetId {SubmissionSetId}. Retrying in {DelayMs}ms... Attempt {RetryCount}/{MaxRetries}",
-                    setId, jitter, retryCount + 1, maxRetries);
-
-                await Task.Delay(jitter);
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(
-                    e,
-                    "Failed to submit SubmissionSetId {SubmissionSetId} after {RetryCount} attempts",
-                    setId, maxRetries);
-                throw;
-            }
+          response.EnsureSuccessStatusCode();
         }
-    }
+        catch (Exception e) when (retryCount < maxRetries - 1)
+        {
+          int delayMs = (int)(Math.Pow(2, retryCount) * 1000);
+          int jitter = rng.Next((int)(delayMs * 0.5), (int)(delayMs * 1.5));
 
+          _logger.LogWarning(
+            e,
+            "Error submitting SubmissionSetId {SubmissionSetId}. Retrying in {DelayMs}ms... Attempt {RetryCount}/{MaxRetries}",
+            setId, jitter, retryCount + 1, maxRetries);
+
+          await Task.Delay(jitter);
+        }
+        catch (Exception e)
+        {
+          _logger.LogError(
+            e,
+            "Failed to submit SubmissionSetId {SubmissionSetId} after {RetryCount} attempts",
+            setId, maxRetries);
+          throw;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
#### Problem

Users were receiving duplicate feedback emails (EM, MP, and QA) for every submission, all arriving at the exact same timestamp. Investigation traced the root cause to `SubmissionJobQueue.cs` in `easey-quartz-scheduler`.

The `SubmitSet` method used retry logic with exponential backoff when calling the `/submission/process` endpoint in `easey-camd-services`. This endpoint is intentionally fire-and-forget and returns **HTTP 202 Accepted** immediately upon receiving the request, then processes asynchronously in the background. The retry logic did not account for this — on any transient network condition, it would re-POST to `/submission/process` with the same `submissionSetId`, triggering a second full execution of `processSubmissionSet` and sending duplicate feedback emails for all file types.

#### Changes Made: 

Updated the `SubmitSet` method in `SubmissionJobQueue.cs` to treat **202 Accepted** and all other 2xx responses as terminal success conditions with an immediate return — no retry. Only genuine non-success HTTP responses now trigger the exponential backoff retry logic.

#### Files Changed

- `easey-quartz-scheduler/admin/Jobs/SubmissionJobQueue.cs`

#### Testing

- Verify that a single submission produces exactly one EM, one MP, and one QA feedback email
- Verify that a genuine HTTP failure (non-2xx) still triggers retry with exponential backoff
- Verify that a 202 response does not trigger any retry attempts in logs

